### PR TITLE
Expose a way to set `publicPath` in `remoteEntry`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ branches:
     - webpack-4
     - master
     - next
+    - dev-1
 
 cache:
   yarn: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ branches:
     - webpack-4
     - master
     - next
+    - dev-1
 
 init:
   - git config --global core.autocrlf input

--- a/declarations/plugins/ContainerPlugin.d.ts
+++ b/declarations/plugins/ContainerPlugin.d.ts
@@ -1,0 +1,46 @@
+/**
+ * This file was automatically generated.
+ * DO NOT MODIFY BY HAND.
+ * Run `yarn special-lint-fix` to update
+ */
+
+export interface ContainerPlugin {
+	/**
+	 * A map of modules you wish to expose
+	 */
+	exposes?:
+		| {
+				[k: string]: any;
+		  }
+		| any[];
+	/**
+	 * The filename for this container relative path inside the `output.path` directory.
+	 */
+	filename?: string;
+	/**
+	 * Type of library
+	 */
+	libraryTarget?:
+		| "var"
+		| "this"
+		| "window"
+		| "self"
+		| "global"
+		| "commonjs"
+		| "commonjs2"
+		| "amd"
+		| "amd-require"
+		| "umd"
+		| "umd2"
+		| "system";
+	/**
+	 * The name for this container
+	 */
+	name: string;
+	/**
+	 * An object for requests to override from host to this container
+	 */
+	overridables?: {
+		[k: string]: any;
+	};
+}

--- a/declarations/plugins/ContainerPlugin.d.ts
+++ b/declarations/plugins/ContainerPlugin.d.ts
@@ -4,7 +4,48 @@
  * Run `yarn special-lint-fix` to update
  */
 
-export interface ContainerPlugin {
+/**
+ * Add a comment in the UMD wrapper.
+ */
+export type AuxiliaryComment = string | LibraryCustomUmdCommentObject;
+/**
+ * Specify which export should be exposed as library
+ */
+export type LibraryExport = string | ArrayOfStringValues;
+/**
+ * Array of strings
+ */
+export type ArrayOfStringValues = string[];
+/**
+ * The name of the library (some types allow unnamed libraries too)
+ */
+export type LibraryName = string | string[] | LibraryCustomUmdObject;
+/**
+ * Type of library
+ */
+export type LibraryType =
+	| "var"
+	| "module"
+	| "assign"
+	| "this"
+	| "window"
+	| "self"
+	| "global"
+	| "commonjs"
+	| "commonjs2"
+	| "commonjs-module"
+	| "amd"
+	| "amd-require"
+	| "umd"
+	| "umd2"
+	| "jsonp"
+	| "system";
+/**
+ * If `output.libraryTarget` is set to umd and `output.library` is set, setting this to true will name the AMD module.
+ */
+export type UmdNamedDefine = boolean;
+
+export interface ContainerPluginOptions {
 	/**
 	 * A map of modules you wish to expose
 	 */
@@ -18,21 +59,9 @@ export interface ContainerPlugin {
 	 */
 	filename?: string;
 	/**
-	 * Type of library
+	 * Options for library
 	 */
-	libraryTarget?:
-		| "var"
-		| "this"
-		| "window"
-		| "self"
-		| "global"
-		| "commonjs"
-		| "commonjs2"
-		| "amd"
-		| "amd-require"
-		| "umd"
-		| "umd2"
-		| "system";
+	library?: LibraryOptions;
 	/**
 	 * The name for this container
 	 */
@@ -40,7 +69,72 @@ export interface ContainerPlugin {
 	/**
 	 * An object for requests to override from host to this container
 	 */
-	overridables?: {
-		[k: string]: any;
-	};
+	overridables?:
+		| {
+				[k: string]: any;
+		  }
+		| any[];
+}
+/**
+ * Options for library
+ */
+export interface LibraryOptions {
+	/**
+	 * Add a comment in the UMD wrapper.
+	 */
+	auxiliaryComment?: AuxiliaryComment;
+	/**
+	 * Specify which export should be exposed as library
+	 */
+	export?: LibraryExport;
+	/**
+	 * The name of the library (some types allow unnamed libraries too)
+	 */
+	name?: LibraryName;
+	/**
+	 * Type of library
+	 */
+	type: LibraryType;
+	/**
+	 * If `output.libraryTarget` is set to umd and `output.library` is set, setting this to true will name the AMD module.
+	 */
+	umdNamedDefine?: UmdNamedDefine;
+}
+/**
+ * Set explicit comments for `commonjs`, `commonjs2`, `amd`, and `root`.
+ */
+export interface LibraryCustomUmdCommentObject {
+	/**
+	 * Set comment for `amd` section in UMD
+	 */
+	amd?: string;
+	/**
+	 * Set comment for `commonjs` (exports) section in UMD
+	 */
+	commonjs?: string;
+	/**
+	 * Set comment for `commonjs2` (module.exports) section in UMD
+	 */
+	commonjs2?: string;
+	/**
+	 * Set comment for `root` (global variable) section in UMD
+	 */
+	root?: string;
+}
+/**
+ * Description object for all UMD variants of the library name
+ */
+export interface LibraryCustomUmdObject {
+	/**
+	 * Name of the exposed AMD library in the UMD
+	 */
+	amd?: string;
+	/**
+	 * Name of the exposed commonjs export in the UMD
+	 */
+	commonjs?: string;
+	/**
+	 * Name of the property exposed globally by a UMD library
+	 */
+	root?: string | ArrayOfStringValues;
 }

--- a/declarations/plugins/ContainerPlugin.d.ts
+++ b/declarations/plugins/ContainerPlugin.d.ts
@@ -9,19 +9,15 @@
  */
 export type AuxiliaryComment = string | LibraryCustomUmdCommentObject;
 /**
- * Specify which export should be exposed as library
+ * Specify which export should be exposed as library.
  */
-export type LibraryExport = string | ArrayOfStringValues;
+export type LibraryExport = string | string[];
 /**
- * Array of strings
- */
-export type ArrayOfStringValues = string[];
-/**
- * The name of the library (some types allow unnamed libraries too)
+ * The name of the library (some types allow unnamed libraries too).
  */
 export type LibraryName = string | string[] | LibraryCustomUmdObject;
 /**
- * Type of library
+ * Type of library.
  */
 export type LibraryType =
 	| "var"
@@ -44,10 +40,14 @@ export type LibraryType =
  * If `output.libraryTarget` is set to umd and `output.library` is set, setting this to true will name the AMD module.
  */
 export type UmdNamedDefine = boolean;
+/**
+ * Array of strings.
+ */
+export type ArrayOfStringValues = string[];
 
 export interface ContainerPluginOptions {
 	/**
-	 * A map of modules you wish to expose
+	 * A map of modules you wish to expose.
 	 */
 	exposes?:
 		| {
@@ -59,15 +59,15 @@ export interface ContainerPluginOptions {
 	 */
 	filename?: string;
 	/**
-	 * Options for library
+	 * Options for library.
 	 */
 	library?: LibraryOptions;
 	/**
-	 * The name for this container
+	 * The name for this container.
 	 */
 	name: string;
 	/**
-	 * An object for requests to override from host to this container
+	 * An object for requests to override from host to this container.
 	 */
 	overridables?:
 		| {
@@ -76,7 +76,7 @@ export interface ContainerPluginOptions {
 		| any[];
 }
 /**
- * Options for library
+ * Options for library.
  */
 export interface LibraryOptions {
 	/**
@@ -84,15 +84,15 @@ export interface LibraryOptions {
 	 */
 	auxiliaryComment?: AuxiliaryComment;
 	/**
-	 * Specify which export should be exposed as library
+	 * Specify which export should be exposed as library.
 	 */
 	export?: LibraryExport;
 	/**
-	 * The name of the library (some types allow unnamed libraries too)
+	 * The name of the library (some types allow unnamed libraries too).
 	 */
 	name?: LibraryName;
 	/**
-	 * Type of library
+	 * Type of library.
 	 */
 	type: LibraryType;
 	/**
@@ -105,36 +105,36 @@ export interface LibraryOptions {
  */
 export interface LibraryCustomUmdCommentObject {
 	/**
-	 * Set comment for `amd` section in UMD
+	 * Set comment for `amd` section in UMD.
 	 */
 	amd?: string;
 	/**
-	 * Set comment for `commonjs` (exports) section in UMD
+	 * Set comment for `commonjs` (exports) section in UMD.
 	 */
 	commonjs?: string;
 	/**
-	 * Set comment for `commonjs2` (module.exports) section in UMD
+	 * Set comment for `commonjs2` (module.exports) section in UMD.
 	 */
 	commonjs2?: string;
 	/**
-	 * Set comment for `root` (global variable) section in UMD
+	 * Set comment for `root` (global variable) section in UMD.
 	 */
 	root?: string;
 }
 /**
- * Description object for all UMD variants of the library name
+ * Description object for all UMD variants of the library name.
  */
 export interface LibraryCustomUmdObject {
 	/**
-	 * Name of the exposed AMD library in the UMD
+	 * Name of the exposed AMD library in the UMD.
 	 */
 	amd?: string;
 	/**
-	 * Name of the exposed commonjs export in the UMD
+	 * Name of the exposed commonjs export in the UMD.
 	 */
 	commonjs?: string;
 	/**
-	 * Name of the property exposed globally by a UMD library
+	 * Name of the property exposed globally by a UMD library.
 	 */
-	root?: string | ArrayOfStringValues;
+	root?: string | string[];
 }

--- a/declarations/plugins/ContainerReferencePlugin.d.ts
+++ b/declarations/plugins/ContainerReferencePlugin.d.ts
@@ -1,0 +1,28 @@
+/**
+ * This file was automatically generated.
+ * DO NOT MODIFY BY HAND.
+ * Run `yarn special-lint-fix` to update
+ */
+
+export type ContainerReferencePlugin = {
+	/**
+	 * A list of requests that should be overridable by the host container
+	 */
+	overrides?:
+		| any[]
+		| {
+				[k: string]: any;
+		  };
+	/**
+	 * The libraryTarget of a remote build
+	 */
+	remoteType?: string;
+	/**
+	 * A list of remote scopes or namespaces that reference federated Webpack instances
+	 */
+	remotes?:
+		| any[]
+		| {
+				[k: string]: any;
+		  };
+};

--- a/declarations/plugins/ContainerReferencePlugin.d.ts
+++ b/declarations/plugins/ContainerReferencePlugin.d.ts
@@ -6,7 +6,7 @@
 
 export type ContainerReferencePlugin = {
 	/**
-	 * A list of requests that should be overridable by the host container
+	 * A list of requests that should be overridable by the host container.
 	 */
 	overrides?:
 		| any[]
@@ -14,11 +14,11 @@ export type ContainerReferencePlugin = {
 				[k: string]: any;
 		  };
 	/**
-	 * The libraryTarget of a remote build
+	 * The libraryTarget of a remote build.
 	 */
 	remoteType?: string;
 	/**
-	 * A list of remote scopes or namespaces that reference federated Webpack instances
+	 * A list of remote scopes or namespaces that reference federated Webpack instances.
 	 */
 	remotes?:
 		| any[]

--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -73,6 +73,12 @@ const REPLACEMENTS = {
 		type: "function",
 		assign: true
 	},
+	__webpack_override__: {
+		expr: `Object.assign.bind(Object, ${RuntimeGlobals.overrides})`,
+		req: [RuntimeGlobals.overrides],
+		type: "function",
+		assign: false
+	},
 	"require.onError": {
 		expr: RuntimeGlobals.uncaughtErrorHandler,
 		req: [RuntimeGlobals.uncaughtErrorHandler],

--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -73,12 +73,6 @@ const REPLACEMENTS = {
 		type: "function",
 		assign: true
 	},
-	__webpack_override__: {
-		expr: `Object.assign.bind(Object, ${RuntimeGlobals.overrides})`,
-		req: [RuntimeGlobals.overrides],
-		type: "function",
-		assign: false
-	},
 	"require.onError": {
 		expr: RuntimeGlobals.uncaughtErrorHandler,
 		req: [RuntimeGlobals.uncaughtErrorHandler],

--- a/lib/ChunkGroup.js
+++ b/lib/ChunkGroup.js
@@ -29,7 +29,7 @@ const {
  * @property {number=} prefetchOrder
  */
 
-/** @typedef {RawChunkGroupOptions & { name: string }} ChunkGroupOptions */
+/** @typedef {RawChunkGroupOptions & { name?: string }} ChunkGroupOptions */
 
 let debugId = 5000;
 

--- a/lib/RuntimeGlobals.js
+++ b/lib/RuntimeGlobals.js
@@ -196,6 +196,11 @@ exports.interceptModuleExecution = "__webpack_require__.i";
 exports.global = "__webpack_require__.g";
 
 /**
+ * the overrides mapping
+ */
+exports.overrides = "__webpack_require__.O";
+
+/**
  * the filename of the HMR manifest
  */
 exports.getUpdateManifestFilename = "__webpack_require__.hmrF";

--- a/lib/container/ContainerEntryDependency.js
+++ b/lib/container/ContainerEntryDependency.js
@@ -1,0 +1,25 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra, Zackary Jackson @ScriptedAlchemy, Marais Rossouw @maraisr
+*/
+
+"use strict";
+
+const EntryDependency = require("../dependencies/EntryDependency");
+const makeSerializable = require("../util/makeSerializable");
+
+class ContainerEntryDependency extends EntryDependency {
+	constructor(exposes, name) {
+		super(null);
+		this.exposes = exposes;
+		this.optional = true;
+		this.loc = { name };
+	}
+}
+
+makeSerializable(
+	ContainerEntryDependency,
+	"webpack/lib/container/ContainerEntryDependency"
+);
+
+module.exports = ContainerEntryDependency;

--- a/lib/container/ContainerEntryDependency.js
+++ b/lib/container/ContainerEntryDependency.js
@@ -9,11 +9,13 @@ const EntryDependency = require("../dependencies/EntryDependency");
 const makeSerializable = require("../util/makeSerializable");
 
 class ContainerEntryDependency extends EntryDependency {
-	constructor(exposes, name) {
+	/**
+	 * @param {[string, string][]} exposes list of exposed modules
+	 */
+	constructor(exposes) {
 		super(null);
 		this.exposes = exposes;
 		this.optional = true;
-		this.loc = { name };
 	}
 }
 

--- a/lib/container/ContainerEntryDependency.js
+++ b/lib/container/ContainerEntryDependency.js
@@ -17,6 +17,10 @@ class ContainerEntryDependency extends EntryDependency {
 		this.exposes = exposes;
 		this.optional = true;
 	}
+
+	get type() {
+		return "container entry";
+	}
 }
 
 makeSerializable(

--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -1,0 +1,198 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra, Zackary Jackson @ScriptedAlchemy, Marais Rossouw @maraisr
+*/
+
+"use strict";
+
+const { ConcatSource } = require("webpack-sources");
+const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
+const Module = require("../Module");
+const RuntimeGlobals = require("../RuntimeGlobals");
+const Template = require("../Template");
+const ContainerExposedDependency = require("./ContainerExposedDependency");
+
+/** @typedef {import("../../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
+/** @typedef {import("../ChunkGraph")} ChunkGraph */
+/** @typedef {import("../ChunkGroup")} ChunkGroup */
+/** @typedef {import("../Compilation")} Compilation */
+/** @typedef {import("../Module").CodeGenerationContext} CodeGenerationContext */
+/** @typedef {import("../Module").CodeGenerationResult} CodeGenerationResult */
+/** @typedef {import("../Module").NeedBuildContext} NeedBuildContext */
+/** @typedef {import("../RequestShortener")} RequestShortener */
+/** @typedef {import("../ResolverFactory").ResolverWithOptions} ResolverWithOptions */
+/** @typedef {import("../WebpackError")} WebpackError */
+/** @typedef {import("../util/Hash")} Hash */
+/** @typedef {import("../util/fs").InputFileSystem} InputFileSystem */
+/** @typedef {import("./ContainerEntryDependency")} ContainerEntryDependency */
+
+const SOURCE_TYPES = new Set(["javascript"]);
+const RUNTIME_REQUIREMENTS = new Set([
+	RuntimeGlobals.definePropertyGetters,
+	RuntimeGlobals.exports,
+	RuntimeGlobals.returnExportsFromRuntime
+]);
+
+module.exports = class ContainerEntryModule extends Module {
+	constructor(dependency) {
+		super("javascript/dynamic", null);
+		this.exposes = dependency.exposes;
+		this.dependencies /** @type {ContainerEntryDependency[]} */ = [];
+		this.blocks = [];
+	}
+
+	/**
+	 * @returns {Set<string>} types availiable (do not mutate)
+	 */
+	getSourceTypes() {
+		return SOURCE_TYPES;
+	}
+
+	/**
+	 * @returns {string} a unique identifier of the module
+	 */
+	identifier() {
+		return `container entry ${JSON.stringify(this.exposes)}`;
+	}
+
+	/**
+	 * @param {RequestShortener} requestShortener the request shortener
+	 * @returns {string} a user readable identifier of the module
+	 */
+	readableIdentifier(requestShortener) {
+		return `container entry`;
+	}
+
+	/**
+	 * @param {NeedBuildContext} context context info
+	 * @param {function(WebpackError=, boolean=): void} callback callback function, returns true, if the module needs a rebuild
+	 * @returns {void}
+	 */
+	needBuild(context, callback) {
+		return callback(null, !this.buildMeta);
+	}
+
+	/**
+	 * @param {WebpackOptions} options webpack options
+	 * @param {Compilation} compilation the compilation
+	 * @param {ResolverWithOptions} resolver the resolver
+	 * @param {InputFileSystem} fs the file system
+	 * @param {function(WebpackError=): void} callback callback function
+	 * @returns {void}
+	 */
+	build(options, compilation, resolver, fs, callback) {
+		this.buildMeta = {};
+		this.buildInfo = {
+			strict: true
+		};
+
+		this.clearDependenciesAndBlocks();
+
+		let idx = -1;
+		for (const [name, request] of Object.entries(this.exposes)) {
+			++idx;
+			const dep = new ContainerExposedDependency(name, request);
+			dep.loc = {
+				name,
+				index: idx
+			};
+
+			this.dependencies.push(dep);
+		}
+
+		for (const dep of this.dependencies) {
+			const block = new AsyncDependenciesBlock(
+				undefined,
+				dep.loc,
+				dep.userRequest
+			);
+			block.addDependency(dep);
+			this.addBlock(block);
+		}
+
+		callback();
+	}
+
+	/**
+	 * @param {CodeGenerationContext} context context for code generation
+	 * @returns {CodeGenerationResult} result
+	 */
+	codeGeneration({ moduleGraph, chunkGraph, runtimeTemplate }) {
+		const sources = new Map();
+		const runtimeRequirements = RUNTIME_REQUIREMENTS;
+		const getters = [];
+
+		for (const block of this.blocks) {
+			const {
+				dependencies: [dep]
+			} = block;
+			const name = dep.exposedName;
+			const mod = moduleGraph.getModule(dep);
+			const request = dep.userRequest;
+
+			let str;
+
+			if (!mod) {
+				str = runtimeTemplate.throwMissingModuleErrorBlock({
+					request: dep.userRequest
+				});
+			} else {
+				str = `return ${runtimeTemplate.blockPromise({
+					block,
+					message: request,
+					chunkGraph,
+					runtimeRequirements
+				})}.then(${runtimeTemplate.basicFunction(
+					"",
+					`return ${runtimeTemplate.moduleRaw({
+						module: mod,
+						chunkGraph,
+						request,
+						weak: false,
+						runtimeRequirements
+					})}`
+				)});`;
+			}
+
+			getters.push(
+				`${Template.toNormalComment(
+					`[${name}] => ${request}`
+				)}"${name}": ${runtimeTemplate.basicFunction("", str)}`
+			);
+		}
+
+		sources.set(
+			"javascript",
+			new ConcatSource(
+				`\n${
+					runtimeTemplate.supportsConst() ? "const" : "var"
+				} __MODULE_MAP__ = {${getters.join(",")}};`,
+				`\n${
+					runtimeTemplate.supportsConst() ? "const" : "var"
+				} __GET_MODULE__ = ${runtimeTemplate.basicFunction(
+					["module"],
+					`return typeof __MODULE_MAP__[module] ==='function' ? __MODULE_MAP__[module].apply(null) : Promise.reject(new Error('Module ' + module + ' does not exist.'))`
+				)};`,
+				`\n\nmodule.exports = {${Template.indent([
+					`\nget: ${runtimeTemplate.basicFunction(
+						"",
+						"return __GET_MODULE__"
+					)},`
+				])}};`
+			)
+		);
+
+		return {
+			sources,
+			runtimeRequirements
+		};
+	}
+
+	/**
+	 * @param {string=} type the source type for which the size should be estimated
+	 * @returns {number} the estimated size of the module (must be non-zero)
+	 */
+	size(type) {
+		return 42;
+	}
+};

--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -38,7 +38,7 @@ module.exports = class ContainerEntryModule extends Module {
 	}
 
 	/**
-	 * @returns {Set<string>} types availiable (do not mutate)
+	 * @returns {Set<string>} types available (do not mutate)
 	 */
 	getSourceTypes() {
 		return SOURCE_TYPES;

--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-const { ConcatSource } = require("webpack-sources");
+const { RawSource } = require("webpack-sources");
 const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
 const Module = require("../Module");
 const RuntimeGlobals = require("../RuntimeGlobals");
@@ -29,16 +29,16 @@ const ContainerExposedDependency = require("./ContainerExposedDependency");
 const SOURCE_TYPES = new Set(["javascript"]);
 const RUNTIME_REQUIREMENTS = new Set([
 	RuntimeGlobals.definePropertyGetters,
-	RuntimeGlobals.exports,
-	RuntimeGlobals.returnExportsFromRuntime
+	RuntimeGlobals.exports
 ]);
 
 module.exports = class ContainerEntryModule extends Module {
-	constructor(dependency) {
+	/**
+	 * @param {[string, string][]} exposes list of exposed modules
+	 */
+	constructor(exposes) {
 		super("javascript/dynamic", null);
-		this.exposes = dependency.exposes;
-		this.dependencies /** @type {ContainerEntryDependency[]} */ = [];
-		this.blocks = [];
+		this.exposes = exposes;
 	}
 
 	/**
@@ -88,8 +88,10 @@ module.exports = class ContainerEntryModule extends Module {
 
 		this.clearDependenciesAndBlocks();
 
+		const dependencies = [];
+
 		let idx = -1;
-		for (const [name, request] of Object.entries(this.exposes)) {
+		for (const [name, request] of this.exposes) {
 			++idx;
 			const dep = new ContainerExposedDependency(name, request);
 			dep.loc = {
@@ -97,15 +99,11 @@ module.exports = class ContainerEntryModule extends Module {
 				index: idx
 			};
 
-			this.dependencies.push(dep);
+			dependencies.push(dep);
 		}
 
-		for (const dep of this.dependencies) {
-			const block = new AsyncDependenciesBlock(
-				undefined,
-				dep.loc,
-				dep.userRequest
-			);
+		for (const dep of dependencies) {
+			const block = new AsyncDependenciesBlock(undefined, dep.loc, dep.request);
 			block.addDependency(dep);
 			this.addBlock(block);
 		}
@@ -124,8 +122,9 @@ module.exports = class ContainerEntryModule extends Module {
 
 		for (const block of this.blocks) {
 			const {
-				dependencies: [dep]
+				dependencies: [dependency]
 			} = block;
+			const dep = /** @type {ContainerExposedDependency} */ (dependency);
 			const name = dep.exposedName;
 			const mod = moduleGraph.getModule(dep);
 			const request = dep.userRequest;
@@ -142,43 +141,44 @@ module.exports = class ContainerEntryModule extends Module {
 					message: request,
 					chunkGraph,
 					runtimeRequirements
-				})}.then(${runtimeTemplate.basicFunction(
-					"",
-					`return ${runtimeTemplate.moduleRaw({
-						module: mod,
-						chunkGraph,
-						request,
-						weak: false,
-						runtimeRequirements
-					})}`
+				})}.then(${runtimeTemplate.returningFunction(
+					runtimeTemplate.returningFunction(
+						runtimeTemplate.moduleRaw({
+							module: mod,
+							chunkGraph,
+							request,
+							weak: false,
+							runtimeRequirements
+						})
+					)
 				)});`;
 			}
 
 			getters.push(
 				`${Template.toNormalComment(
 					`[${name}] => ${request}`
-				)}"${name}": ${runtimeTemplate.basicFunction("", str)}`
+				)} "${name}": ${runtimeTemplate.basicFunction("", str)}`
 			);
 		}
 
 		sources.set(
 			"javascript",
-			new ConcatSource(
-				`\n${
-					runtimeTemplate.supportsConst() ? "const" : "var"
-				} __MODULE_MAP__ = {${getters.join(",")}};`,
-				`\n${
-					runtimeTemplate.supportsConst() ? "const" : "var"
-				} __GET_MODULE__ = ${runtimeTemplate.basicFunction(
-					["module"],
-					`return typeof __MODULE_MAP__[module] ==='function' ? __MODULE_MAP__[module].apply(null) : Promise.reject(new Error('Module ' + module + ' does not exist.'))`
-				)};`,
-				`\n\nmodule.exports = {${Template.indent([
-					`\nget: ${runtimeTemplate.basicFunction(
-						"",
-						"return __GET_MODULE__"
-					)},`
-				])}};`
+			new RawSource(
+				Template.asString([
+					`var __MODULE_MAP__ = {`,
+					Template.indent(getters.join(",")),
+					"};",
+					`var __GET_MODULE__ = ${runtimeTemplate.basicFunction(
+						["module"],
+						`return typeof __MODULE_MAP__[module] ==='function' ? __MODULE_MAP__[module].apply(null) : Promise.reject(new Error('Module ' + module + ' does not exist.'))`
+					)};`,
+					"",
+					`${RuntimeGlobals.definePropertyGetters}(exports, {`,
+					Template.indent([
+						`get: ${runtimeTemplate.returningFunction("__GET_MODULE__")}`
+					]),
+					"});"
+				])
 			)
 		);
 

--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -27,10 +27,6 @@ const ContainerExposedDependency = require("./ContainerExposedDependency");
 /** @typedef {import("./ContainerEntryDependency")} ContainerEntryDependency */
 
 const SOURCE_TYPES = new Set(["javascript"]);
-const RUNTIME_REQUIREMENTS = new Set([
-	RuntimeGlobals.definePropertyGetters,
-	RuntimeGlobals.exports
-]);
 
 module.exports = class ContainerEntryModule extends Module {
 	/**
@@ -117,7 +113,10 @@ module.exports = class ContainerEntryModule extends Module {
 	 */
 	codeGeneration({ moduleGraph, chunkGraph, runtimeTemplate }) {
 		const sources = new Map();
-		const runtimeRequirements = RUNTIME_REQUIREMENTS;
+		const runtimeRequirements = new Set([
+			RuntimeGlobals.definePropertyGetters,
+			RuntimeGlobals.exports
+		]);
 		const getters = [];
 
 		for (const block of this.blocks) {
@@ -172,10 +171,15 @@ module.exports = class ContainerEntryModule extends Module {
 						["module"],
 						`return typeof __MODULE_MAP__[module] ==='function' ? __MODULE_MAP__[module].apply(null) : Promise.reject(new Error('Module ' + module + ' does not exist.'))`
 					)};`,
+					`var __OVERRIDE__ = ${runtimeTemplate.basicFunction(
+						"override",
+						`Object.assign(${RuntimeGlobals.overrides}, override);`
+					)}`,
 					"",
 					`${RuntimeGlobals.definePropertyGetters}(exports, {`,
 					Template.indent([
-						`get: ${runtimeTemplate.returningFunction("__GET_MODULE__")}`
+						`get: ${runtimeTemplate.returningFunction("__GET_MODULE__")},`,
+						`override: ${runtimeTemplate.returningFunction("__OVERRIDE__")}`
 					]),
 					"});"
 				])

--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-const { RawSource } = require("webpack-sources");
+const { OriginalSource } = require("webpack-sources");
 const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
 const Module = require("../Module");
 const RuntimeGlobals = require("../RuntimeGlobals");
@@ -159,41 +159,41 @@ module.exports = class ContainerEntryModule extends Module {
 			);
 		}
 
+		const source = Template.asString([
+			`var moduleMap = {`,
+			Template.indent(getters.join(",\n")),
+			"};",
+			`var get = ${runtimeTemplate.basicFunction("module", [
+				"return (",
+				Template.indent([
+					`${RuntimeGlobals.hasOwnProperty}(moduleMap, module)`,
+					Template.indent([
+						"? moduleMap[module]()",
+						`: Promise.resolve().then(${runtimeTemplate.basicFunction(
+							"",
+							'throw new Error("Module " + module + " does not exist in container.");'
+						)})`
+					])
+				]),
+				");"
+			])};`,
+			`var override = ${runtimeTemplate.basicFunction(
+				"override",
+				`Object.assign(${RuntimeGlobals.overrides}, override);`
+			)}`,
+			"",
+			"// This exports getters to disallow modifications",
+			`${RuntimeGlobals.definePropertyGetters}(exports, {`,
+			Template.indent([
+				`get: ${runtimeTemplate.returningFunction("get")},`,
+				`override: ${runtimeTemplate.returningFunction("override")}`
+			]),
+			"});"
+		]);
+
 		sources.set(
 			"javascript",
-			new RawSource(
-				Template.asString([
-					`var moduleMap = {`,
-					Template.indent(getters.join(",\n")),
-					"};",
-					`var get = ${runtimeTemplate.basicFunction("module", [
-						"return (",
-						Template.indent([
-							`${RuntimeGlobals.hasOwnProperty}(moduleMap, module)`,
-							Template.indent([
-								"? moduleMap[module]()",
-								`: Promise.resolve().then(${runtimeTemplate.basicFunction(
-									"",
-									'throw new Error("Module " + module + " does not exist in container.");'
-								)})`
-							])
-						]),
-						");"
-					])};`,
-					`var override = ${runtimeTemplate.basicFunction(
-						"override",
-						`Object.assign(${RuntimeGlobals.overrides}, override);`
-					)}`,
-					"",
-					"// This exports getters to disallow modifications",
-					`${RuntimeGlobals.definePropertyGetters}(exports, {`,
-					Template.indent([
-						`get: ${runtimeTemplate.returningFunction("get")},`,
-						`override: ${runtimeTemplate.returningFunction("override")}`
-					]),
-					"});"
-				])
-			)
+			new OriginalSource(source, "webpack/container-entry")
 		);
 
 		return {

--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -115,6 +115,7 @@ module.exports = class ContainerEntryModule extends Module {
 		const sources = new Map();
 		const runtimeRequirements = new Set([
 			RuntimeGlobals.definePropertyGetters,
+			RuntimeGlobals.hasOwnProperty,
 			RuntimeGlobals.exports
 		]);
 		const getters = [];
@@ -137,7 +138,7 @@ module.exports = class ContainerEntryModule extends Module {
 			} else {
 				str = `return ${runtimeTemplate.blockPromise({
 					block,
-					message: request,
+					message: "",
 					chunkGraph,
 					runtimeRequirements
 				})}.then(${runtimeTemplate.returningFunction(
@@ -154,9 +155,7 @@ module.exports = class ContainerEntryModule extends Module {
 			}
 
 			getters.push(
-				`${Template.toNormalComment(
-					`[${name}] => ${request}`
-				)} "${name}": ${runtimeTemplate.basicFunction("", str)}`
+				`${JSON.stringify(name)}: ${runtimeTemplate.basicFunction("", str)}`
 			);
 		}
 
@@ -164,22 +163,33 @@ module.exports = class ContainerEntryModule extends Module {
 			"javascript",
 			new RawSource(
 				Template.asString([
-					`var __MODULE_MAP__ = {`,
-					Template.indent(getters.join(",")),
+					`var moduleMap = {`,
+					Template.indent(getters.join(",\n")),
 					"};",
-					`var __GET_MODULE__ = ${runtimeTemplate.basicFunction(
-						["module"],
-						`return typeof __MODULE_MAP__[module] ==='function' ? __MODULE_MAP__[module].apply(null) : Promise.reject(new Error('Module ' + module + ' does not exist.'))`
-					)};`,
-					`var __OVERRIDE__ = ${runtimeTemplate.basicFunction(
+					`var get = ${runtimeTemplate.basicFunction("module", [
+						"return (",
+						Template.indent([
+							`${RuntimeGlobals.hasOwnProperty}(moduleMap, module)`,
+							Template.indent([
+								"? moduleMap[module]()",
+								`: Promise.resolve().then(${runtimeTemplate.basicFunction(
+									"",
+									'throw new Error("Module " + module + " does not exist in container.");'
+								)})`
+							])
+						]),
+						");"
+					])};`,
+					`var override = ${runtimeTemplate.basicFunction(
 						"override",
 						`Object.assign(${RuntimeGlobals.overrides}, override);`
 					)}`,
 					"",
+					"// This exports getters to disallow modifications",
 					`${RuntimeGlobals.definePropertyGetters}(exports, {`,
 					Template.indent([
-						`get: ${runtimeTemplate.returningFunction("__GET_MODULE__")},`,
-						`override: ${runtimeTemplate.returningFunction("__OVERRIDE__")}`
+						`get: ${runtimeTemplate.returningFunction("get")},`,
+						`override: ${runtimeTemplate.returningFunction("override")}`
 					]),
 					"});"
 				])

--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -181,12 +181,17 @@ module.exports = class ContainerEntryModule extends Module {
 				"override",
 				`Object.assign(${RuntimeGlobals.overrides}, override);`
 			)}`,
+			`var setPublicPath = ${runtimeTemplate.basicFunction(
+				"path",
+				`${RuntimeGlobals.publicPath} = path;`
+			)}`,
 			"",
 			"// This exports getters to disallow modifications",
 			`${RuntimeGlobals.definePropertyGetters}(exports, {`,
 			Template.indent([
 				`get: ${runtimeTemplate.returningFunction("get")},`,
-				`override: ${runtimeTemplate.returningFunction("override")}`
+				`override: ${runtimeTemplate.returningFunction("override")},`,
+				`setPublicPath: ${runtimeTemplate.returningFunction("setPublicPath")}`
 			]),
 			"});"
 		]);

--- a/lib/container/ContainerEntryModuleFactory.js
+++ b/lib/container/ContainerEntryModuleFactory.js
@@ -1,0 +1,25 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra, Zackary Jackson @ScriptedAlchemy, Marais Rossouw @maraisr
+*/
+
+"use strict";
+
+const ModuleFactory = require("../ModuleFactory");
+const ContainerEntryModule = require("./ContainerEntryModule");
+
+/** @typedef {import("../ModuleFactory").ModuleFactoryCreateData} ModuleFactoryCreateData */
+/** @typedef {import("../ModuleFactory").ModuleFactoryResult} ModuleFactoryResult */
+
+module.exports = class ContainerEntryModuleFactory extends ModuleFactory {
+	/**
+	 * @param {ModuleFactoryCreateData} data data object
+	 * @param {function(Error=, ModuleFactoryResult=): void} callback callback
+	 * @returns {void}
+	 */
+	create({ dependencies: [dependency] }, callback) {
+		callback(null, {
+			module: new ContainerEntryModule(dependency)
+		});
+	}
+};

--- a/lib/container/ContainerEntryModuleFactory.js
+++ b/lib/container/ContainerEntryModuleFactory.js
@@ -10,6 +10,7 @@ const ContainerEntryModule = require("./ContainerEntryModule");
 
 /** @typedef {import("../ModuleFactory").ModuleFactoryCreateData} ModuleFactoryCreateData */
 /** @typedef {import("../ModuleFactory").ModuleFactoryResult} ModuleFactoryResult */
+/** @typedef {import("./ContainerEntryDependency")} ContainerEntryDependency */
 
 module.exports = class ContainerEntryModuleFactory extends ModuleFactory {
 	/**
@@ -18,8 +19,9 @@ module.exports = class ContainerEntryModuleFactory extends ModuleFactory {
 	 * @returns {void}
 	 */
 	create({ dependencies: [dependency] }, callback) {
+		const dep = /** @type {ContainerEntryDependency} */ (dependency);
 		callback(null, {
-			module: new ContainerEntryModule(dependency)
+			module: new ContainerEntryModule(dep.exposes)
 		});
 	}
 };

--- a/lib/container/ContainerExposedDependency.js
+++ b/lib/container/ContainerExposedDependency.js
@@ -1,0 +1,34 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra, Zackary Jackson @ScriptedAlchemy, Marais Rossouw @maraisr
+*/
+
+"use strict";
+
+const ModuleDependency = require("../dependencies/ModuleDependency");
+const makeSerializable = require("../util/makeSerializable");
+
+class ContainerExposedDependency extends ModuleDependency {
+	constructor(name, request) {
+		super(request);
+		this._name = name;
+	}
+
+	get exposedName() {
+		return this._name;
+	}
+
+	/**
+	 * @returns {string | null} an identifier to merge equal requests
+	 */
+	getResourceIdentifier() {
+		return `exposed dependency ${this._name}`;
+	}
+}
+
+makeSerializable(
+	ContainerExposedDependency,
+	"webpack/lib/container/ContainerExposedDependency"
+);
+
+module.exports = ContainerExposedDependency;

--- a/lib/container/ContainerExposedDependency.js
+++ b/lib/container/ContainerExposedDependency.js
@@ -14,6 +14,10 @@ class ContainerExposedDependency extends ModuleDependency {
 		this.exposedName = exposedName;
 	}
 
+	get type() {
+		return "container exposed";
+	}
+
 	/**
 	 * @returns {string | null} an identifier to merge equal requests
 	 */

--- a/lib/container/ContainerExposedDependency.js
+++ b/lib/container/ContainerExposedDependency.js
@@ -9,20 +9,26 @@ const ModuleDependency = require("../dependencies/ModuleDependency");
 const makeSerializable = require("../util/makeSerializable");
 
 class ContainerExposedDependency extends ModuleDependency {
-	constructor(name, request) {
+	constructor(exposedName, request) {
 		super(request);
-		this._name = name;
-	}
-
-	get exposedName() {
-		return this._name;
+		this.exposedName = exposedName;
 	}
 
 	/**
 	 * @returns {string | null} an identifier to merge equal requests
 	 */
 	getResourceIdentifier() {
-		return `exposed dependency ${this._name}`;
+		return `exposed dependency ${this.exposedName}`;
+	}
+
+	serialize(context) {
+		context.write(this.exposedName);
+		super.serialize(context);
+	}
+
+	deserialize(context) {
+		this.exposedName = context.read();
+		super.deserialize(context);
 	}
 }
 

--- a/lib/container/ContainerPlugin.js
+++ b/lib/container/ContainerPlugin.js
@@ -1,0 +1,157 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra, Zackary Jackson @ScriptedAlchemy, Marais Rossouw @maraisr
+*/
+
+"use strict";
+
+const Template = require("../Template");
+const JavascriptModulesPlugin = require("../javascript/JavascriptModulesPlugin");
+const propertyAccess = require("../util/propertyAccess");
+const ContainerEntryDependency = require("./ContainerEntryDependency");
+const ContainerEntryModuleFactory = require("./ContainerEntryModuleFactory");
+const ContainerExposedDependency = require("./ContainerExposedDependency");
+
+const validateOptions = require("schema-utils");
+const { ConcatSource } = require("webpack-sources");
+
+const schema = require("../../schemas/plugins/ContainerPlugin.json");
+const parseOptions = require("./parseOptions");
+
+/** @typedef {import("../Compiler")} Compiler */
+
+const PLUGIN_NAME = "ContainerPlugin";
+
+module.exports = class ContainerPlugin {
+	constructor(options) {
+		validateOptions(schema, options, { name: PLUGIN_NAME });
+
+		this.options = {
+			overridables: options.overridables || null,
+			name: options.name,
+			libraryTarget: options.libraryTarget || "var",
+			filename: options.filename || undefined,
+			exposes: parseOptions(options.exposes)
+		};
+	}
+
+	/**
+	 * @param {Compiler} compiler the compiler instance
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		if (compiler.options.optimization.runtimeChunk) {
+			throw new Error(
+				"This plugin cannot integrate with RuntimeChunk plugin, please remote `optimization.runtimeChunk`."
+			);
+		}
+
+		if (typeof compiler.options.output.jsonpFunction === "undefined") {
+			compiler.options.output.jsonpFunction = Template.toIdentifier(
+				"webpackJsonp" + this.options.name
+			);
+		}
+
+		if (typeof compiler.options.output.chunkCallbackName === "undefined") {
+			compiler.options.output.chunkCallbackName = Template.toIdentifier(
+				"webpackChunk" + this.options.name
+			);
+		}
+
+		compiler.hooks.make.tapAsync(PLUGIN_NAME, (compilation, callback) => {
+			/** @type {Object|any[]} */
+			let exposedMap = this.options.exposes;
+
+			if (Array.isArray(this.options.exposes)) {
+				exposedMap = {};
+				for (const exp of this.options.exposes) {
+					// TODO: Check if this regex handles all cases
+					exposedMap[exp.replace(/(^(?:[^\w])+)/, "")] = exp;
+				}
+			}
+
+			compilation.addEntry(
+				compilation.options.context,
+				new ContainerEntryDependency(exposedMap, this.options.name),
+				this.options.name,
+				error => {
+					if (error) return callback(error);
+					callback();
+				}
+			);
+		});
+
+		compiler.hooks.thisCompilation.tap(
+			PLUGIN_NAME,
+			(compilation, { normalModuleFactory }) => {
+				compilation.dependencyFactories.set(
+					ContainerEntryDependency,
+					new ContainerEntryModuleFactory()
+				);
+
+				compilation.dependencyFactories.set(
+					ContainerExposedDependency,
+					normalModuleFactory
+				);
+
+				const renderHooks = JavascriptModulesPlugin.getCompilationHooks(
+					compilation
+				);
+
+				renderHooks.render.tap(PLUGIN_NAME, (source, { chunk }) => {
+					if (chunk.name === this.options.name) {
+						const libName = Template.toIdentifier(
+							compilation.getPath(this.options.name, {
+								chunk
+							})
+						);
+
+						switch (this.options.libraryTarget) {
+							case "var": {
+								return new ConcatSource(`var ${libName} =`, source);
+							}
+							case "this":
+							case "window":
+							case "self":
+								return new ConcatSource(
+									`${this.options.libraryTarget}${propertyAccess([libName])} =`,
+									source
+								);
+							case "global":
+								return new ConcatSource(
+									`${compiler.options.output.globalObject}${propertyAccess([
+										libName
+									])} =`,
+									source
+								);
+							case "commonjs":
+							case "commonjs2": {
+								return new ConcatSource(
+									`exports${propertyAccess([libName])} =`,
+									source
+								);
+							}
+							case "amd": // TODO: Solve this?
+							case "amd-require": // TODO: Solve this?
+							case "umd": // TODO: Solve this?
+							case "umd2": // TODO: Solve this?
+							case "system": // TODO: Solve this?
+							default:
+								throw new Error(
+									`${this.options.libraryTarget} is not a valid Library target`
+								);
+						}
+					}
+				});
+
+				compilation.hooks.afterChunks.tap(PLUGIN_NAME, chunks => {
+					for (const chunk of chunks) {
+						if (chunk.name === this.options.name) {
+							chunk.filenameTemplate = this.options.filename;
+						}
+					}
+				});
+			}
+		);
+	}
+};

--- a/lib/container/ContainerPlugin.js
+++ b/lib/container/ContainerPlugin.js
@@ -5,17 +5,16 @@
 
 "use strict";
 
+const validateOptions = require("schema-utils");
+const { ConcatSource } = require("webpack-sources");
+const schema = require("../../schemas/plugins/ContainerPlugin.json");
+const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
 const JavascriptModulesPlugin = require("../javascript/JavascriptModulesPlugin");
 const propertyAccess = require("../util/propertyAccess");
 const ContainerEntryDependency = require("./ContainerEntryDependency");
 const ContainerEntryModuleFactory = require("./ContainerEntryModuleFactory");
 const ContainerExposedDependency = require("./ContainerExposedDependency");
-
-const validateOptions = require("schema-utils");
-const { ConcatSource } = require("webpack-sources");
-
-const schema = require("../../schemas/plugins/ContainerPlugin.json");
 const parseOptions = require("./parseOptions");
 
 /** @typedef {import("../Compiler")} Compiler */
@@ -27,7 +26,7 @@ module.exports = class ContainerPlugin {
 		validateOptions(schema, options, { name: PLUGIN_NAME });
 
 		this.options = {
-			overridables: options.overridables || null,
+			overridables: parseOptions(options.overridables),
 			name: options.name,
 			libraryTarget: options.libraryTarget || "var",
 			filename: options.filename || undefined,
@@ -40,40 +39,18 @@ module.exports = class ContainerPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
-		if (compiler.options.optimization.runtimeChunk) {
-			throw new Error(
-				"This plugin cannot integrate with RuntimeChunk plugin, please remote `optimization.runtimeChunk`."
-			);
-		}
-
-		if (typeof compiler.options.output.jsonpFunction === "undefined") {
-			compiler.options.output.jsonpFunction = Template.toIdentifier(
-				"webpackJsonp" + this.options.name
-			);
-		}
-
-		if (typeof compiler.options.output.chunkCallbackName === "undefined") {
-			compiler.options.output.chunkCallbackName = Template.toIdentifier(
-				"webpackChunk" + this.options.name
-			);
-		}
-
 		compiler.hooks.make.tapAsync(PLUGIN_NAME, (compilation, callback) => {
-			/** @type {Object|any[]} */
-			let exposedMap = this.options.exposes;
+			const { name, exposes, filename } = this.options;
 
-			if (Array.isArray(this.options.exposes)) {
-				exposedMap = {};
-				for (const exp of this.options.exposes) {
-					// TODO: Check if this regex handles all cases
-					exposedMap[exp.replace(/(^(?:[^\w])+)/, "")] = exp;
-				}
-			}
-
+			const dep = new ContainerEntryDependency(exposes);
+			dep.loc = { name };
 			compilation.addEntry(
 				compilation.options.context,
-				new ContainerEntryDependency(exposedMap, this.options.name),
-				this.options.name,
+				dep,
+				{
+					name,
+					filename
+				},
 				error => {
 					if (error) return callback(error);
 					callback();
@@ -92,6 +69,17 @@ module.exports = class ContainerPlugin {
 				compilation.dependencyFactories.set(
 					ContainerExposedDependency,
 					normalModuleFactory
+				);
+
+				// TODO: refactor to new library system
+				const { name } = this.options;
+
+				compilation.hooks.additionalTreeRuntimeRequirements.tap(
+					PLUGIN_NAME,
+					(chunk, set) => {
+						if (chunk.name === name)
+							set.add(RuntimeGlobals.returnExportsFromRuntime);
+					}
 				);
 
 				const renderHooks = JavascriptModulesPlugin.getCompilationHooks(
@@ -140,14 +128,6 @@ module.exports = class ContainerPlugin {
 								throw new Error(
 									`${this.options.libraryTarget} is not a valid Library target`
 								);
-						}
-					}
-				});
-
-				compilation.hooks.afterChunks.tap(PLUGIN_NAME, chunks => {
-					for (const chunk of chunks) {
-						if (chunk.name === this.options.name) {
-							chunk.filenameTemplate = this.options.filename;
 						}
 					}
 				});

--- a/lib/container/ContainerPlugin.js
+++ b/lib/container/ContainerPlugin.js
@@ -10,6 +10,7 @@ const schema = require("../../schemas/plugins/ContainerPlugin.json");
 const ContainerEntryDependency = require("./ContainerEntryDependency");
 const ContainerEntryModuleFactory = require("./ContainerEntryModuleFactory");
 const ContainerExposedDependency = require("./ContainerExposedDependency");
+const OverridablesPlugin = require("./OverridablesPlugin");
 const parseOptions = require("./parseOptions");
 
 /** @typedef {import("../../declarations/plugins/ContainerPlugin").ContainerPluginOptions} ContainerPluginOptions */
@@ -25,7 +26,7 @@ module.exports = class ContainerPlugin {
 		validateOptions(schema, options, { name: PLUGIN_NAME });
 
 		this.options = {
-			overridables: parseOptions(options.overridables),
+			overridables: options.overridables,
 			name: options.name,
 			library: options.library || {
 				type: "var",
@@ -41,9 +42,11 @@ module.exports = class ContainerPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
-		const { name, exposes, filename, library } = this.options;
+		const { name, exposes, filename, library, overridables } = this.options;
 
 		compiler.options.output.enabledLibraryTypes.push(library.type);
+
+		new OverridablesPlugin(overridables).apply(compiler);
 
 		compiler.hooks.make.tapAsync(PLUGIN_NAME, (compilation, callback) => {
 			const dep = new ContainerEntryDependency(exposes);

--- a/lib/container/ContainerPlugin.js
+++ b/lib/container/ContainerPlugin.js
@@ -6,29 +6,31 @@
 "use strict";
 
 const validateOptions = require("schema-utils");
-const { ConcatSource } = require("webpack-sources");
 const schema = require("../../schemas/plugins/ContainerPlugin.json");
-const RuntimeGlobals = require("../RuntimeGlobals");
-const Template = require("../Template");
-const JavascriptModulesPlugin = require("../javascript/JavascriptModulesPlugin");
-const propertyAccess = require("../util/propertyAccess");
 const ContainerEntryDependency = require("./ContainerEntryDependency");
 const ContainerEntryModuleFactory = require("./ContainerEntryModuleFactory");
 const ContainerExposedDependency = require("./ContainerExposedDependency");
 const parseOptions = require("./parseOptions");
 
+/** @typedef {import("../../declarations/plugins/ContainerPlugin").ContainerPluginOptions} ContainerPluginOptions */
 /** @typedef {import("../Compiler")} Compiler */
 
 const PLUGIN_NAME = "ContainerPlugin";
 
 module.exports = class ContainerPlugin {
+	/**
+	 * @param {ContainerPluginOptions} options options
+	 */
 	constructor(options) {
 		validateOptions(schema, options, { name: PLUGIN_NAME });
 
 		this.options = {
 			overridables: parseOptions(options.overridables),
 			name: options.name,
-			libraryTarget: options.libraryTarget || "var",
+			library: options.library || {
+				type: "var",
+				name: options.name
+			},
 			filename: options.filename || undefined,
 			exposes: parseOptions(options.exposes)
 		};
@@ -39,9 +41,11 @@ module.exports = class ContainerPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
-		compiler.hooks.make.tapAsync(PLUGIN_NAME, (compilation, callback) => {
-			const { name, exposes, filename } = this.options;
+		const { name, exposes, filename, library } = this.options;
 
+		compiler.options.output.enabledLibraryTypes.push(library.type);
+
+		compiler.hooks.make.tapAsync(PLUGIN_NAME, (compilation, callback) => {
 			const dep = new ContainerEntryDependency(exposes);
 			dep.loc = { name };
 			compilation.addEntry(
@@ -49,7 +53,8 @@ module.exports = class ContainerPlugin {
 				dep,
 				{
 					name,
-					filename
+					filename,
+					library
 				},
 				error => {
 					if (error) return callback(error);
@@ -70,67 +75,6 @@ module.exports = class ContainerPlugin {
 					ContainerExposedDependency,
 					normalModuleFactory
 				);
-
-				// TODO: refactor to new library system
-				const { name } = this.options;
-
-				compilation.hooks.additionalTreeRuntimeRequirements.tap(
-					PLUGIN_NAME,
-					(chunk, set) => {
-						if (chunk.name === name)
-							set.add(RuntimeGlobals.returnExportsFromRuntime);
-					}
-				);
-
-				const renderHooks = JavascriptModulesPlugin.getCompilationHooks(
-					compilation
-				);
-
-				renderHooks.render.tap(PLUGIN_NAME, (source, { chunk }) => {
-					if (chunk.name === this.options.name) {
-						const libName = Template.toIdentifier(
-							compilation.getPath(this.options.name, {
-								chunk
-							})
-						);
-
-						switch (this.options.libraryTarget) {
-							case "var": {
-								return new ConcatSource(`var ${libName} =`, source);
-							}
-							case "this":
-							case "window":
-							case "self":
-								return new ConcatSource(
-									`${this.options.libraryTarget}${propertyAccess([libName])} =`,
-									source
-								);
-							case "global":
-								return new ConcatSource(
-									`${compiler.options.output.globalObject}${propertyAccess([
-										libName
-									])} =`,
-									source
-								);
-							case "commonjs":
-							case "commonjs2": {
-								return new ConcatSource(
-									`exports${propertyAccess([libName])} =`,
-									source
-								);
-							}
-							case "amd": // TODO: Solve this?
-							case "amd-require": // TODO: Solve this?
-							case "umd": // TODO: Solve this?
-							case "umd2": // TODO: Solve this?
-							case "system": // TODO: Solve this?
-							default:
-								throw new Error(
-									`${this.options.libraryTarget} is not a valid Library target`
-								);
-						}
-					}
-				});
 			}
 		);
 	}

--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -13,6 +13,8 @@ const RemoteRuntimeModule = require("./RemoteRuntimeModule");
 const RemoteToExternalDependency = require("./RemoteToExternalDependency");
 const RemoteToOverrideDependency = require("./RemoteToOverrideDependency");
 const parseOptions = require("./parseOptions");
+const schema = require("../../schemas/plugins/ContainerReferencePlugin.json");
+const validateOptions = require("schema-utils");
 
 /** @typedef {import("../Compiler")} Compiler */
 
@@ -22,6 +24,9 @@ module.exports = class ContainerReferencePlugin {
 		this.remotes = parseOptions(options.remotes || []);
 		this.overrides = parseOptions(options.overrides || {});
 
+		validateOptions(schema, options, {
+			name: "Container Reference Plugin"
+		});
 		// TODO: Apply some validation around what was passed in.
 	}
 

--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -9,6 +9,7 @@ const ExternalsPlugin = require("../ExternalsPlugin");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RemoteModule = require("./RemoteModule");
 const RemoteRuntimeModule = require("./RemoteRuntimeModule");
+const RemoteOverrideModule = require("./RemoteOverrideModule");
 const RemoteToExternalDependency = require("./RemoteToExternalDependency");
 const parseOptions = require("./parseOptions");
 
@@ -18,7 +19,7 @@ module.exports = class ContainerReferencePlugin {
 	constructor(options) {
 		this.remoteType = options.remoteType || "global";
 		this.remotes = parseOptions(options.remotes || []);
-		this.override = parseOptions(options.override || {});
+		this.overrides = parseOptions(options.overrides || {});
 
 		// TODO: Apply some validation around what was passed in.
 	}
@@ -53,11 +54,26 @@ module.exports = class ContainerReferencePlugin {
 								if (data.request.startsWith(`${key}/`)) {
 									return new RemoteModule(
 										data.request,
-										`container-reference/${key}`,
+										`${
+											this.overrides.length ? "remote-override-module/" : ""
+										}container-reference/${key}`,
 										data.request.slice(key.length + 1)
 									);
 								}
 							}
+						}
+					}
+				);
+
+				normalModuleFactory.hooks.factorize.tap(
+					"ContainerReferencePlugin",
+					data => {
+						// TODO use a custom dependency and factory instead
+						if (data.request.startsWith(`remote-override-module/`)) {
+							return new RemoteOverrideModule(
+								data.request.slice(`remote-override-module/`.length),
+								this.overrides
+							);
 						}
 					}
 				);

--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -1,0 +1,78 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra and Zackary Jackson @ScriptedAlchemy
+*/
+
+"use strict";
+
+const ExternalsPlugin = require("../ExternalsPlugin");
+const RuntimeGlobals = require("../RuntimeGlobals");
+const RemoteModule = require("./RemoteModule");
+const RemoteRuntimeModule = require("./RemoteRuntimeModule");
+const RemoteToExternalDependency = require("./RemoteToExternalDependency");
+const parseOptions = require("./parseOptions");
+
+/** @typedef {import("../Compiler")} Compiler */
+
+module.exports = class ContainerReferencePlugin {
+	constructor(options) {
+		this.remoteType = options.remoteType || "global";
+		this.remotes = parseOptions(options.remotes || []);
+		this.override = parseOptions(options.override || {});
+
+		// TODO: Apply some validation around what was passed in.
+	}
+
+	/**
+	 * @param {Compiler} compiler webpack compiler
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		const { remotes, remoteType } = this;
+
+		const remoteExternals = {};
+		for (const [key, value] of remotes) {
+			remoteExternals[`container-reference/${key}`] = value;
+		}
+
+		new ExternalsPlugin(remoteType, remoteExternals).apply(compiler);
+
+		compiler.hooks.compilation.tap(
+			"ContainerReferencePlugin",
+			(compilation, { normalModuleFactory }) => {
+				compilation.dependencyFactories.set(
+					RemoteToExternalDependency,
+					normalModuleFactory
+				);
+
+				normalModuleFactory.hooks.factorize.tap(
+					"ContainerReferencePlugin",
+					data => {
+						if (!data.request.includes("!")) {
+							for (const [key] of remotes) {
+								if (data.request.startsWith(`${key}/`)) {
+									return new RemoteModule(
+										data.request,
+										`container-reference/${key}`,
+										data.request.slice(key.length + 1)
+									);
+								}
+							}
+						}
+					}
+				);
+
+				compilation.hooks.additionalTreeRuntimeRequirements.tap(
+					"OverridablesPlugin",
+					(chunk, set) => {
+						set.add(RuntimeGlobals.module);
+						set.add(RuntimeGlobals.moduleFactories);
+						set.add(RuntimeGlobals.hasOwnProperty);
+						set.add(RuntimeGlobals.ensureChunkHandlers);
+						compilation.addRuntimeModule(chunk, new RemoteRuntimeModule());
+					}
+				);
+			}
+		);
+	}
+};

--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -16,6 +16,8 @@ const RemoteRuntimeModule = require("./RemoteRuntimeModule");
 const RemoteToExternalDependency = require("./RemoteToExternalDependency");
 const RemoteToOverrideDependency = require("./RemoteToOverrideDependency");
 const parseOptions = require("./parseOptions");
+const schema = require("../../schemas/plugins/ContainerReferencePlugin.json");
+const validateOptions = require("schema-utils");
 
 /** @typedef {import("../Compiler")} Compiler */
 

--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -10,6 +10,7 @@ const schema = require("../../schemas/plugins/ContainerReferencePlugin.json");
 const ExternalsPlugin = require("../ExternalsPlugin");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RemoteModule = require("./RemoteModule");
+const RemoteOverrideDependency = require("./RemoteOverrideDependency");
 const RemoteOverrideModuleFactory = require("./RemoteOverrideModuleFactory");
 const RemoteRuntimeModule = require("./RemoteRuntimeModule");
 const RemoteToExternalDependency = require("./RemoteToExternalDependency");
@@ -49,6 +50,11 @@ module.exports = class ContainerReferencePlugin {
 			(compilation, { normalModuleFactory }) => {
 				compilation.dependencyFactories.set(
 					RemoteToExternalDependency,
+					normalModuleFactory
+				);
+
+				compilation.dependencyFactories.set(
+					RemoteOverrideDependency,
 					normalModuleFactory
 				);
 

--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -5,6 +5,8 @@
 
 "use strict";
 
+const validateOptions = require("schema-utils");
+const schema = require("../../schemas/plugins/ContainerReferencePlugin.json");
 const ExternalsPlugin = require("../ExternalsPlugin");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RemoteModule = require("./RemoteModule");
@@ -13,8 +15,6 @@ const RemoteRuntimeModule = require("./RemoteRuntimeModule");
 const RemoteToExternalDependency = require("./RemoteToExternalDependency");
 const RemoteToOverrideDependency = require("./RemoteToOverrideDependency");
 const parseOptions = require("./parseOptions");
-const schema = require("../../schemas/plugins/ContainerReferencePlugin.json");
-const validateOptions = require("schema-utils");
 
 /** @typedef {import("../Compiler")} Compiler */
 

--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -75,16 +75,14 @@ module.exports = class ContainerReferencePlugin {
 					}
 				);
 
-				compilation.hooks.additionalTreeRuntimeRequirements.tap(
-					"OverridablesPlugin",
-					(chunk, set) => {
+				compilation.hooks.runtimeRequirementInTree
+					.for(RuntimeGlobals.ensureChunkHandlers)
+					.tap("OverridablesPlugin", (chunk, set) => {
 						set.add(RuntimeGlobals.module);
 						set.add(RuntimeGlobals.moduleFactories);
 						set.add(RuntimeGlobals.hasOwnProperty);
-						set.add(RuntimeGlobals.ensureChunkHandlers);
 						compilation.addRuntimeModule(chunk, new RemoteRuntimeModule());
-					}
-				);
+					});
 			}
 		);
 	}

--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -16,8 +16,6 @@ const RemoteRuntimeModule = require("./RemoteRuntimeModule");
 const RemoteToExternalDependency = require("./RemoteToExternalDependency");
 const RemoteToOverrideDependency = require("./RemoteToOverrideDependency");
 const parseOptions = require("./parseOptions");
-const schema = require("../../schemas/plugins/ContainerReferencePlugin.json");
-const validateOptions = require("schema-utils");
 
 /** @typedef {import("../Compiler")} Compiler */
 

--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -8,9 +8,10 @@
 const ExternalsPlugin = require("../ExternalsPlugin");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RemoteModule = require("./RemoteModule");
+const RemoteOverrideModuleFactory = require("./RemoteOverrideModuleFactory");
 const RemoteRuntimeModule = require("./RemoteRuntimeModule");
-const RemoteOverrideModule = require("./RemoteOverrideModule");
 const RemoteToExternalDependency = require("./RemoteToExternalDependency");
+const RemoteToOverrideDependency = require("./RemoteToOverrideDependency");
 const parseOptions = require("./parseOptions");
 
 /** @typedef {import("../Compiler")} Compiler */
@@ -46,6 +47,11 @@ module.exports = class ContainerReferencePlugin {
 					normalModuleFactory
 				);
 
+				compilation.dependencyFactories.set(
+					RemoteToOverrideDependency,
+					new RemoteOverrideModuleFactory()
+				);
+
 				normalModuleFactory.hooks.factorize.tap(
 					"ContainerReferencePlugin",
 					data => {
@@ -54,26 +60,12 @@ module.exports = class ContainerReferencePlugin {
 								if (data.request.startsWith(`${key}/`)) {
 									return new RemoteModule(
 										data.request,
-										`${
-											this.overrides.length ? "remote-override-module/" : ""
-										}container-reference/${key}`,
+										this.overrides,
+										`container-reference/${key}`,
 										data.request.slice(key.length + 1)
 									);
 								}
 							}
-						}
-					}
-				);
-
-				normalModuleFactory.hooks.factorize.tap(
-					"ContainerReferencePlugin",
-					data => {
-						// TODO use a custom dependency and factory instead
-						if (data.request.startsWith(`remote-override-module/`)) {
-							return new RemoteOverrideModule(
-								data.request.slice(`remote-override-module/`.length),
-								this.overrides
-							);
 						}
 					}
 				);

--- a/lib/container/ModuleFederationPlugin.js
+++ b/lib/container/ModuleFederationPlugin.js
@@ -1,0 +1,40 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra and Zackary Jackson @ScriptedAlchemy
+*/
+
+"use strict";
+
+const ContainerPlugin = require("./ContainerPlugin");
+const ContainerReferencePlugin = require("./ContainerReferencePlugin");
+
+/** @typedef {import("../Compiler")} Compiler */
+
+class ModuleFederationPlugin {
+	constructor(options) {
+		// TODO options validation
+		this.options = options;
+	}
+
+	/**
+	 * @param {Compiler} compiler webpack compiler
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		const { options } = this;
+		new ContainerPlugin({
+			name: options.name,
+			library: options.library,
+			filename: options.filename,
+			exposes: options.exposes,
+			overridables: options.shared
+		}).apply(compiler);
+		new ContainerReferencePlugin({
+			remoteType: options.remoteType || options.library.type,
+			remotes: options.remotes,
+			overrides: options.shared
+		}).apply(compiler);
+	}
+}
+
+module.exports = ModuleFederationPlugin;

--- a/lib/container/OverridableModule.js
+++ b/lib/container/OverridableModule.js
@@ -1,0 +1,166 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const { RawSource } = require("webpack-sources");
+const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
+const Module = require("../Module");
+const RuntimeGlobals = require("../RuntimeGlobals");
+const Template = require("../Template");
+const makeSerializable = require("../util/makeSerializable");
+const OverridableOriginalDependency = require("./OverridableOriginalDependency");
+
+/** @typedef {import("../../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
+/** @typedef {import("../ChunkGraph")} ChunkGraph */
+/** @typedef {import("../ChunkGroup")} ChunkGroup */
+/** @typedef {import("../Compilation")} Compilation */
+/** @typedef {import("../Module").CodeGenerationContext} CodeGenerationContext */
+/** @typedef {import("../Module").CodeGenerationResult} CodeGenerationResult */
+/** @typedef {import("../RequestShortener")} RequestShortener */
+/** @typedef {import("../ResolverFactory").ResolverWithOptions} ResolverWithOptions */
+/** @typedef {import("../WebpackError")} WebpackError */
+/** @typedef {import("../util/Hash")} Hash */
+/** @typedef {import("../util/fs").InputFileSystem} InputFileSystem */
+
+const TYPES = new Set(["overridable"]);
+
+class OverridableModule extends Module {
+	/**
+	 * @param {Module} originalModule original module
+	 * @param {string} name global overridable name
+	 */
+	constructor(originalModule, name) {
+		super("overridable-module", originalModule.context);
+		this.originalModule = originalModule;
+		this.name = name;
+	}
+
+	/**
+	 * @returns {string} a unique identifier of the module
+	 */
+	identifier() {
+		return `overridable|${this.name}|${this.originalModule.identifier()}`;
+	}
+
+	/**
+	 * @param {RequestShortener} requestShortener the request shortener
+	 * @returns {string} a user readable identifier of the module
+	 */
+	readableIdentifier(requestShortener) {
+		return `overridable ${
+			this.name
+		} -> ${this.originalModule.readableIdentifier(requestShortener)}`;
+	}
+
+	/**
+	 * @param {WebpackOptions} options webpack options
+	 * @param {Compilation} compilation the compilation
+	 * @param {ResolverWithOptions} resolver the resolver
+	 * @param {InputFileSystem} fs the file system
+	 * @param {function(WebpackError=): void} callback callback function
+	 * @returns {void}
+	 */
+	build(options, compilation, resolver, fs, callback) {
+		this.buildMeta = {};
+		this.buildInfo = {};
+		const block = new AsyncDependenciesBlock({});
+		const dep = new OverridableOriginalDependency(this.originalModule);
+		block.addDependency(dep);
+		this.addBlock(block);
+		callback();
+	}
+
+	/**
+	 * @returns {Set<string>} types availiable (do not mutate)
+	 */
+	getSourceTypes() {
+		return TYPES;
+	}
+
+	/**
+	 * @param {string=} type the source type for which the size should be estimated
+	 * @returns {number} the estimated size of the module (must be non-zero)
+	 */
+	size(type) {
+		return 42;
+	}
+
+	/**
+	 * Assuming this module is in the cache. Update the (cached) module with
+	 * the fresh module from the factory. Usually updates internal references
+	 * and properties.
+	 * @param {Module} module fresh module
+	 * @returns {void}
+	 */
+	updateCacheModule(module) {
+		super.updateCacheModule(module);
+		this.originalModule =
+			/** @type {OverridableModule} */ (module).originalModule;
+	}
+
+	/**
+	 * @param {Hash} hash the hash used to track dependencies
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @returns {void}
+	 */
+	updateHash(hash, chunkGraph) {
+		hash.update(this.name);
+		super.updateHash(hash, chunkGraph);
+	}
+
+	/**
+	 * @param {CodeGenerationContext} context context for code generation
+	 * @returns {CodeGenerationResult} result
+	 */
+	codeGeneration({ chunkGraph, moduleGraph, runtimeTemplate }) {
+		const runtimeRequirements = new Set([RuntimeGlobals.overrides]);
+		const originalBlock = this.blocks[0];
+		const originalDep = originalBlock.dependencies[0];
+		const originalModule = moduleGraph.getModule(originalDep);
+		const ensureChunk = runtimeTemplate.blockPromise({
+			block: originalBlock,
+			message: "",
+			chunkGraph,
+			runtimeRequirements
+		});
+		const sources = new Map();
+		sources.set(
+			"overridable",
+			new RawSource(
+				Template.asString([
+					`return ${ensureChunk}.then(${runtimeTemplate.returningFunction(
+						runtimeTemplate.returningFunction(
+							runtimeTemplate.moduleRaw({
+								module: originalModule,
+								chunkGraph,
+								request: "",
+								runtimeRequirements
+							})
+						)
+					)})`
+				])
+			)
+		);
+		return {
+			runtimeRequirements,
+			sources
+		};
+	}
+
+	serialize(context) {
+		context.write(this.name);
+		super.serialize(context);
+	}
+
+	deserialize(context) {
+		this.name = context.read();
+		super.deserialize(context);
+	}
+}
+
+makeSerializable(OverridableModule, "webpack/lib/container/OverridableModule");
+
+module.exports = OverridableModule;

--- a/lib/container/OverridableModule.js
+++ b/lib/container/OverridableModule.js
@@ -74,7 +74,7 @@ class OverridableModule extends Module {
 	}
 
 	/**
-	 * @returns {Set<string>} types availiable (do not mutate)
+	 * @returns {Set<string>} types available (do not mutate)
 	 */
 	getSourceTypes() {
 		return TYPES;

--- a/lib/container/OverridableOriginalDependency.js
+++ b/lib/container/OverridableOriginalDependency.js
@@ -1,0 +1,44 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const Dependency = require("../Dependency");
+const makeSerializable = require("../util/makeSerializable");
+
+class OverridableOriginalDependency extends Dependency {
+	constructor(originalModule) {
+		super();
+		this.originalModule = originalModule;
+	}
+
+	/**
+	 * @returns {string | null} an identifier to merge equal requests
+	 */
+	getResourceIdentifier() {
+		return this.originalModule.identifier();
+	}
+
+	get type() {
+		return "overridable original";
+	}
+
+	serialize(context) {
+		context.write(this.originalModule);
+		super.serialize(context);
+	}
+
+	deserialize(context) {
+		this.originalModule = context.read();
+		super.deserialize(context);
+	}
+}
+
+makeSerializable(
+	OverridableOriginalDependency,
+	"webpack/lib/container/OverridableOriginalDependency"
+);
+
+module.exports = OverridableOriginalDependency;

--- a/lib/container/OverridableOriginalModuleFactory.js
+++ b/lib/container/OverridableOriginalModuleFactory.js
@@ -1,0 +1,29 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const ModuleFactory = require("../ModuleFactory");
+
+/** @typedef {import("../ModuleFactory").ModuleFactoryCreateData} ModuleFactoryCreateData */
+/** @typedef {import("../ModuleFactory").ModuleFactoryResult} ModuleFactoryResult */
+/** @typedef {import("./OverridableOriginalDependency")} OverridableOriginalDependency */
+
+class OverridableOriginalModuleFactory extends ModuleFactory {
+	/**
+	 * @param {ModuleFactoryCreateData} data data object
+	 * @param {function(Error=, ModuleFactoryResult=): void} callback callback
+	 * @returns {void}
+	 */
+	create(data, callback) {
+		const dep =
+			/** @type {OverridableOriginalDependency} */ (data.dependencies[0]);
+		callback(null, {
+			module: dep.originalModule
+		});
+	}
+}
+
+module.exports = OverridableOriginalModuleFactory;

--- a/lib/container/OverridablesPlugin.js
+++ b/lib/container/OverridablesPlugin.js
@@ -1,0 +1,111 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const ModuleNotFoundError = require("../ModuleNotFoundError");
+const RuntimeGlobals = require("../RuntimeGlobals");
+const OverridableModule = require("./OverridableModule");
+const OverridableOriginalDependency = require("./OverridableOriginalDependency");
+const OverridableOriginalModuleFactory = require("./OverridableOriginalModuleFactory");
+const OverridablesRuntimeModule = require("./OverridablesRuntimeModule");
+
+/** @typedef {import("../Compiler")} Compiler */
+
+const parseOptions = (prefix, options, result) => {
+	if (Array.isArray(options)) {
+		for (const item of options) {
+			parseOptions(prefix, item, result);
+		}
+	} else if (typeof options === "string") {
+		result.push([prefix + options.replace(/^([^\w]+\/)+/, ""), options]);
+	} else if (options && typeof options === "object") {
+		for (const key of Object.keys(options)) {
+			const value = options[key];
+			if (typeof value === "string") {
+				result.push([prefix + key, value]);
+			} else {
+				parseOptions(prefix + key + "/", value, result);
+			}
+		}
+	}
+};
+
+class OverridablesPlugin {
+	constructor(options) {
+		this.overridables = [];
+		parseOptions("", options, this.overridables);
+	}
+	/**
+	 * @param {Compiler} compiler webpack compiler
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap(
+			"OverridablesPlugin",
+			(compilation, { normalModuleFactory }) => {
+				compilation.dependencyFactories.set(
+					OverridableOriginalDependency,
+					new OverridableOriginalModuleFactory()
+				);
+
+				const resolvedOverridables = new Map();
+				const promise = Promise.all(
+					this.overridables.map(([key, request]) => {
+						const resolver = compilation.resolverFactory.get("normal");
+						return new Promise((resolve, reject) => {
+							resolver.resolve(
+								{},
+								compiler.context,
+								request,
+								{},
+								(err, result) => {
+									if (err) {
+										compilation.errors.push(
+											new ModuleNotFoundError(null, err, {
+												name: `overridable ${key}`
+											})
+										);
+										return resolve();
+									}
+									resolvedOverridables.set(result, key);
+									resolve();
+								}
+							);
+						});
+					})
+				);
+				normalModuleFactory.hooks.afterResolve.tapAsync(
+					"OverridablesPlugin",
+					(resolveData, callback) => {
+						// wait for resolving to be complete
+						promise.then(() => callback());
+					}
+				);
+				normalModuleFactory.hooks.module.tap(
+					"OverridablesPlugin",
+					(module, createData) => {
+						const key = resolvedOverridables.get(createData.resource);
+						if (key !== undefined) return new OverridableModule(module, key);
+					}
+				);
+				compilation.hooks.additionalTreeRuntimeRequirements.tap(
+					"OverridablesPlugin",
+					(chunk, set) => {
+						set.add(RuntimeGlobals.module);
+						set.add(RuntimeGlobals.hasOwnProperty);
+						set.add(RuntimeGlobals.ensureChunkHandlers);
+						compilation.addRuntimeModule(
+							chunk,
+							new OverridablesRuntimeModule()
+						);
+					}
+				);
+			}
+		);
+	}
+}
+
+module.exports = OverridablesPlugin;

--- a/lib/container/OverridablesPlugin.js
+++ b/lib/container/OverridablesPlugin.js
@@ -11,32 +11,13 @@ const OverridableModule = require("./OverridableModule");
 const OverridableOriginalDependency = require("./OverridableOriginalDependency");
 const OverridableOriginalModuleFactory = require("./OverridableOriginalModuleFactory");
 const OverridablesRuntimeModule = require("./OverridablesRuntimeModule");
+const parseOptions = require("./parseOptions");
 
 /** @typedef {import("../Compiler")} Compiler */
 
-const parseOptions = (prefix, options, result) => {
-	if (Array.isArray(options)) {
-		for (const item of options) {
-			parseOptions(prefix, item, result);
-		}
-	} else if (typeof options === "string") {
-		result.push([prefix + options.replace(/^([^\w]+\/)+/, ""), options]);
-	} else if (options && typeof options === "object") {
-		for (const key of Object.keys(options)) {
-			const value = options[key];
-			if (typeof value === "string") {
-				result.push([prefix + key, value]);
-			} else {
-				parseOptions(prefix + key + "/", value, result);
-			}
-		}
-	}
-};
-
 class OverridablesPlugin {
 	constructor(options) {
-		this.overridables = [];
-		parseOptions("", options, this.overridables);
+		this.overridables = parseOptions(options);
 	}
 	/**
 	 * @param {Compiler} compiler webpack compiler
@@ -95,6 +76,7 @@ class OverridablesPlugin {
 					"OverridablesPlugin",
 					(chunk, set) => {
 						set.add(RuntimeGlobals.module);
+						set.add(RuntimeGlobals.moduleFactories);
 						set.add(RuntimeGlobals.hasOwnProperty);
 						set.add(RuntimeGlobals.ensureChunkHandlers);
 						compilation.addRuntimeModule(

--- a/lib/container/OverridablesPlugin.js
+++ b/lib/container/OverridablesPlugin.js
@@ -12,6 +12,10 @@ const OverridableOriginalDependency = require("./OverridableOriginalDependency")
 const OverridableOriginalModuleFactory = require("./OverridableOriginalModuleFactory");
 const OverridablesRuntimeModule = require("./OverridablesRuntimeModule");
 const parseOptions = require("./parseOptions");
+const {
+	toConstantDependency,
+	evaluateToString
+} = require("../javascript/JavascriptParserHelpers");
 
 /** @typedef {import("../Compiler")} Compiler */
 
@@ -83,6 +87,30 @@ class OverridablesPlugin {
 							new OverridablesRuntimeModule()
 						);
 					});
+				const handler = parser => {
+					parser.hooks.expression
+						.for("__webpack_override__")
+						.tap(
+							"OverridablesPlugin",
+							toConstantDependency(
+								parser,
+								`Object.assign.bind(Object, ${RuntimeGlobals.overrides})`,
+								[RuntimeGlobals.overrides]
+							)
+						);
+					parser.hooks.evaluateTypeof
+						.for("__webpack_override__")
+						.tap("OverridablesPlugin", evaluateToString("function"));
+				};
+				normalModuleFactory.hooks.parser
+					.for("javascript/auto")
+					.tap("APIPlugin", handler);
+				normalModuleFactory.hooks.parser
+					.for("javascript/dynamic")
+					.tap("APIPlugin", handler);
+				normalModuleFactory.hooks.parser
+					.for("javascript/esm")
+					.tap("APIPlugin", handler);
 			}
 		);
 	}

--- a/lib/container/OverridablesPlugin.js
+++ b/lib/container/OverridablesPlugin.js
@@ -7,16 +7,18 @@
 
 const ModuleNotFoundError = require("../ModuleNotFoundError");
 const RuntimeGlobals = require("../RuntimeGlobals");
+const {
+	toConstantDependency,
+	evaluateToString
+} = require("../javascript/JavascriptParserHelpers");
+const LazySet = require("../util/LazySet");
 const OverridableModule = require("./OverridableModule");
 const OverridableOriginalDependency = require("./OverridableOriginalDependency");
 const OverridableOriginalModuleFactory = require("./OverridableOriginalModuleFactory");
 const OverridablesRuntimeModule = require("./OverridablesRuntimeModule");
 const parseOptions = require("./parseOptions");
-const {
-	toConstantDependency,
-	evaluateToString
-} = require("../javascript/JavascriptParserHelpers");
 
+/** @typedef {import("enhanced-resolve").ResolveContext} ResolveContext */
 /** @typedef {import("../Compiler")} Compiler */
 
 class OverridablesPlugin {
@@ -37,6 +39,14 @@ class OverridablesPlugin {
 				);
 
 				const resolvedOverridables = new Map();
+				const resolveContext = {
+					/** @type {LazySet<string>} */
+					fileDependencies: new LazySet(),
+					/** @type {LazySet<string>} */
+					contextDependencies: new LazySet(),
+					/** @type {LazySet<string>} */
+					missingDependencies: new LazySet()
+				};
 				const promise = Promise.all(
 					this.overridables.map(([key, request]) => {
 						const resolver = compilation.resolverFactory.get("normal");
@@ -45,7 +55,7 @@ class OverridablesPlugin {
 								{},
 								compiler.context,
 								request,
-								{},
+								resolveContext,
 								(err, result) => {
 									if (err) {
 										compilation.errors.push(
@@ -61,7 +71,15 @@ class OverridablesPlugin {
 							);
 						});
 					})
-				);
+				).then(() => {
+					compilation.contextDependencies.addAll(
+						resolveContext.contextDependencies
+					);
+					compilation.fileDependencies.addAll(resolveContext.fileDependencies);
+					compilation.missingDependencies.addAll(
+						resolveContext.missingDependencies
+					);
+				});
 				normalModuleFactory.hooks.afterResolve.tapAsync(
 					"OverridablesPlugin",
 					(resolveData, callback) => {

--- a/lib/container/OverridablesPlugin.js
+++ b/lib/container/OverridablesPlugin.js
@@ -72,19 +72,17 @@ class OverridablesPlugin {
 						if (key !== undefined) return new OverridableModule(module, key);
 					}
 				);
-				compilation.hooks.additionalTreeRuntimeRequirements.tap(
-					"OverridablesPlugin",
-					(chunk, set) => {
+				compilation.hooks.runtimeRequirementInTree
+					.for(RuntimeGlobals.ensureChunkHandlers)
+					.tap("OverridablesPlugin", (chunk, set) => {
 						set.add(RuntimeGlobals.module);
 						set.add(RuntimeGlobals.moduleFactories);
 						set.add(RuntimeGlobals.hasOwnProperty);
-						set.add(RuntimeGlobals.ensureChunkHandlers);
 						compilation.addRuntimeModule(
 							chunk,
 							new OverridablesRuntimeModule()
 						);
-					}
-				);
+					});
 			}
 		);
 	}

--- a/lib/container/OverridablesPlugin.js
+++ b/lib/container/OverridablesPlugin.js
@@ -17,10 +17,6 @@ const OverridableOriginalDependency = require("./OverridableOriginalDependency")
 const OverridableOriginalModuleFactory = require("./OverridableOriginalModuleFactory");
 const OverridablesRuntimeModule = require("./OverridablesRuntimeModule");
 const parseOptions = require("./parseOptions");
-const {
-	toConstantDependency,
-	evaluateToString
-} = require("../javascript/JavascriptParserHelpers");
 
 /** @typedef {import("enhanced-resolve").ResolveContext} ResolveContext */
 /** @typedef {import("../Compiler")} Compiler */

--- a/lib/container/OverridablesPlugin.js
+++ b/lib/container/OverridablesPlugin.js
@@ -17,6 +17,10 @@ const OverridableOriginalDependency = require("./OverridableOriginalDependency")
 const OverridableOriginalModuleFactory = require("./OverridableOriginalModuleFactory");
 const OverridablesRuntimeModule = require("./OverridablesRuntimeModule");
 const parseOptions = require("./parseOptions");
+const {
+	toConstantDependency,
+	evaluateToString
+} = require("../javascript/JavascriptParserHelpers");
 
 /** @typedef {import("enhanced-resolve").ResolveContext} ResolveContext */
 /** @typedef {import("../Compiler")} Compiler */

--- a/lib/container/OverridablesRuntimeModule.js
+++ b/lib/container/OverridablesRuntimeModule.js
@@ -73,6 +73,7 @@ class OverridablesRuntimeModule extends RuntimeModule {
 				`if(${RuntimeGlobals.hasOwnProperty}(chunkMapping, chunkId)) {`,
 				Template.indent([
 					`chunkMapping[chunkId].forEach(${runtimeTemplate.basicFunction("id", [
+						"if(__webpack_modules__[id]) return;",
 						`promises.push(Promise.resolve((${
 							RuntimeGlobals.overrides
 						}[idToNameMapping[id]] || fallbackMapping[id])()).then(${runtimeTemplate.basicFunction(

--- a/lib/container/OverridablesRuntimeModule.js
+++ b/lib/container/OverridablesRuntimeModule.js
@@ -1,0 +1,95 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const RuntimeGlobals = require("../RuntimeGlobals");
+const RuntimeModule = require("../RuntimeModule");
+const Template = require("../Template");
+
+/** @typedef {import("./OverridableModule")} OverridableModule */
+
+class OverridablesRuntimeModule extends RuntimeModule {
+	constructor() {
+		super("overridables");
+	}
+
+	/**
+	 * @returns {string} runtime code
+	 */
+	generate() {
+		const {
+			runtimeTemplate,
+			chunkGraph,
+			codeGenerationResults
+		} = this.compilation;
+		const chunkToOverridableMapping = {};
+		const idToNameMapping = {};
+		const overridableToFallbackMapping = new Map();
+		for (const chunk of this.chunk.getAllAsyncChunks()) {
+			const modules = chunkGraph.getChunkModulesIterableBySourceType(
+				chunk,
+				"overridable"
+			);
+			if (!modules) continue;
+			const overridables = (chunkToOverridableMapping[chunk.id] = []);
+			for (const m of modules) {
+				const module = /** @type {OverridableModule} */ (m);
+				const name = module.name;
+				const id = chunkGraph.getModuleId(module);
+				overridables.push(id);
+				idToNameMapping[id] = name;
+				const source = codeGenerationResults
+					.get(module)
+					.sources.get("overridable");
+				overridableToFallbackMapping.set(id, source.source());
+			}
+		}
+		return Template.asString([
+			`${RuntimeGlobals.overrides} = {};`,
+			`var chunkMapping = ${JSON.stringify(
+				chunkToOverridableMapping,
+				null,
+				"\t"
+			)};`,
+			`var idToNameMapping = ${JSON.stringify(idToNameMapping, null, "\t")};`,
+			"var fallbackMapping = {",
+			Template.indent(
+				Array.from(
+					overridableToFallbackMapping,
+					([id, source]) =>
+						`${JSON.stringify(id)}: ${runtimeTemplate.basicFunction(
+							"",
+							source
+						)}`
+				).join(",\n")
+			),
+			"};",
+			`${
+				RuntimeGlobals.ensureChunkHandlers
+			}.overridables = ${runtimeTemplate.basicFunction("chunkId, promises", [
+				`if(${RuntimeGlobals.hasOwnProperty}(chunkMapping, chunkId)) {`,
+				Template.indent([
+					`chunkMapping[chunkId].forEach(${runtimeTemplate.basicFunction("id", [
+						`promises.push(Promise.resolve((${
+							RuntimeGlobals.overrides
+						}[idToNameMapping[id]] || fallbackMapping[id])()).then(${runtimeTemplate.basicFunction(
+							"factory",
+							[
+								`__webpack_modules__[id] = ${runtimeTemplate.basicFunction(
+									"module",
+									["module.exports = factory();"]
+								)}`
+							]
+						)}))`
+					])});`
+				]),
+				"}"
+			])}`
+		]);
+	}
+}
+
+module.exports = OverridablesRuntimeModule;

--- a/lib/container/RemoteModule.js
+++ b/lib/container/RemoteModule.js
@@ -1,0 +1,104 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra and Zackary Jackson @ScriptedAlchemy
+*/
+
+"use strict";
+
+const { RawSource } = require("webpack-sources");
+const Module = require("../Module");
+const RuntimeGlobals = require("../RuntimeGlobals");
+const RemoteToExternalDependency = require("./RemoteToExternalDependency");
+
+/** @typedef {import("../../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
+/** @typedef {import("../ChunkGraph")} ChunkGraph */
+/** @typedef {import("../ChunkGroup")} ChunkGroup */
+/** @typedef {import("../Compilation")} Compilation */
+/** @typedef {import("../Module").CodeGenerationContext} CodeGenerationContext */
+/** @typedef {import("../Module").CodeGenerationResult} CodeGenerationResult */
+/** @typedef {import("../RequestShortener")} RequestShortener */
+/** @typedef {import("../ResolverFactory").ResolverWithOptions} ResolverWithOptions */
+/** @typedef {import("../WebpackError")} WebpackError */
+/** @typedef {import("../util/Hash")} Hash */
+/** @typedef {import("../util/fs").InputFileSystem} InputFileSystem */
+
+const TYPES = new Set(["remote"]);
+const RUNTIME_REQUIREMENTS = new Set([RuntimeGlobals.module]);
+
+class RemoteModule extends Module {
+	constructor(request, externalRequest, internalRequest) {
+		super("remote-module");
+		this.request = request;
+		this.externalRequest = externalRequest;
+		this.internalRequest = internalRequest;
+	}
+
+	/**
+	 * @returns {string} a unique identifier of the module
+	 */
+	identifier() {
+		return `remote ${this.externalRequest} ${this.internalRequest}`;
+	}
+
+	/**
+	 * @param {RequestShortener} requestShortener the request shortener
+	 * @returns {string} a user readable identifier of the module
+	 */
+	readableIdentifier(requestShortener) {
+		return `remote ${this.request}`;
+	}
+
+	/**
+	 * @param {WebpackOptions} options webpack options
+	 * @param {Compilation} compilation the compilation
+	 * @param {ResolverWithOptions} resolver the resolver
+	 * @param {InputFileSystem} fs the file system
+	 * @param {function(WebpackError=): void} callback callback function
+	 * @returns {void}
+	 */
+	build(options, compilation, resolver, fs, callback) {
+		this.buildMeta = {};
+		this.buildInfo = {
+			strict: true
+		};
+
+		this.clearDependenciesAndBlocks();
+		this.addDependency(new RemoteToExternalDependency(this.externalRequest));
+
+		callback();
+	}
+
+	/**
+	 * @param {string=} type the source type for which the size should be estimated
+	 * @returns {number} the estimated size of the module (must be non-zero)
+	 */
+	size(type) {
+		return 42;
+	}
+
+	/**
+	 * @returns {Set<string>} types availiable (do not mutate)
+	 */
+	getSourceTypes() {
+		return TYPES;
+	}
+
+	/**
+	 * @returns {string | null} absolute path which should be used for condition matching (usually the resource path)
+	 */
+	nameForCondition() {
+		return this.request;
+	}
+
+	/**
+	 * @param {CodeGenerationContext} context context for code generation
+	 * @returns {CodeGenerationResult} result
+	 */
+	codeGeneration({ runtimeTemplate, moduleGraph, chunkGraph }) {
+		const sources = new Map();
+		sources.set("remote", new RawSource(""));
+		return { sources, runtimeRequirements: RUNTIME_REQUIREMENTS };
+	}
+}
+
+module.exports = RemoteModule;

--- a/lib/container/RemoteModule.js
+++ b/lib/container/RemoteModule.js
@@ -85,7 +85,7 @@ class RemoteModule extends Module {
 	}
 
 	/**
-	 * @returns {Set<string>} types availiable (do not mutate)
+	 * @returns {Set<string>} types available (do not mutate)
 	 */
 	getSourceTypes() {
 		return TYPES;

--- a/lib/container/RemoteModule.js
+++ b/lib/container/RemoteModule.js
@@ -9,6 +9,7 @@ const { RawSource } = require("webpack-sources");
 const Module = require("../Module");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RemoteToExternalDependency = require("./RemoteToExternalDependency");
+const RemoteToOverrideDependency = require("./RemoteToOverrideDependency");
 
 /** @typedef {import("../../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
@@ -26,9 +27,10 @@ const TYPES = new Set(["remote"]);
 const RUNTIME_REQUIREMENTS = new Set([RuntimeGlobals.module]);
 
 class RemoteModule extends Module {
-	constructor(request, externalRequest, internalRequest) {
+	constructor(request, overrides, externalRequest, internalRequest) {
 		super("remote-module");
 		this.request = request;
+		this.overrides = overrides;
 		this.externalRequest = externalRequest;
 		this.internalRequest = internalRequest;
 	}
@@ -63,7 +65,13 @@ class RemoteModule extends Module {
 		};
 
 		this.clearDependenciesAndBlocks();
-		this.addDependency(new RemoteToExternalDependency(this.externalRequest));
+		if (this.overrides.length > 0) {
+			this.addDependency(
+				new RemoteToOverrideDependency(this.externalRequest, this.overrides)
+			);
+		} else {
+			this.addDependency(new RemoteToExternalDependency(this.externalRequest));
+		}
 
 		callback();
 	}

--- a/lib/container/RemoteOverrideDependency.js
+++ b/lib/container/RemoteOverrideDependency.js
@@ -1,0 +1,26 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const ModuleDependency = require("../dependencies/ModuleDependency");
+const makeSerializable = require("../util/makeSerializable");
+
+class RemoteOverrideDependency extends ModuleDependency {
+	constructor(request) {
+		super(request);
+	}
+
+	get type() {
+		return "remote override";
+	}
+}
+
+makeSerializable(
+	RemoteOverrideDependency,
+	"webpack/lib/container/RemoteOverrideDependency"
+);
+
+module.exports = RemoteOverrideDependency;

--- a/lib/container/RemoteOverrideModule.js
+++ b/lib/container/RemoteOverrideModule.js
@@ -1,0 +1,155 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra and Zackary Jackson @ScriptedAlchemy
+*/
+
+"use strict";
+
+const { RawSource } = require("webpack-sources");
+const Module = require("../Module");
+const RuntimeGlobals = require("../RuntimeGlobals");
+const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
+const RemoteToExternalDependency = require("./RemoteToExternalDependency");
+const Template = require("../Template");
+
+/** @typedef {import("../../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
+/** @typedef {import("../ChunkGraph")} ChunkGraph */
+/** @typedef {import("../ChunkGroup")} ChunkGroup */
+/** @typedef {import("../Compilation")} Compilation */
+/** @typedef {import("../Module").CodeGenerationContext} CodeGenerationContext */
+/** @typedef {import("../Module").CodeGenerationResult} CodeGenerationResult */
+/** @typedef {import("../RequestShortener")} RequestShortener */
+/** @typedef {import("../ResolverFactory").ResolverWithOptions} ResolverWithOptions */
+/** @typedef {import("../WebpackError")} WebpackError */
+/** @typedef {import("../util/Hash")} Hash */
+/** @typedef {import("../util/fs").InputFileSystem} InputFileSystem */
+
+const TYPES = new Set(["javascript"]);
+
+class RemoteModule extends Module {
+	constructor(request, overrides) {
+		super("remote-override-module");
+		this.request = request;
+		this.overrides = overrides;
+	}
+
+	/**
+	 * @returns {string} a unique identifier of the module
+	 */
+	identifier() {
+		return `remote override ${this.request}`;
+	}
+
+	/**
+	 * @param {RequestShortener} requestShortener the request shortener
+	 * @returns {string} a user readable identifier of the module
+	 */
+	readableIdentifier(requestShortener) {
+		return `remote override ${this.request}`;
+	}
+
+	/**
+	 * @param {WebpackOptions} options webpack options
+	 * @param {Compilation} compilation the compilation
+	 * @param {ResolverWithOptions} resolver the resolver
+	 * @param {InputFileSystem} fs the file system
+	 * @param {function(WebpackError=): void} callback callback function
+	 * @returns {void}
+	 */
+	build(options, compilation, resolver, fs, callback) {
+		this.buildMeta = {};
+		this.buildInfo = {
+			strict: true
+		};
+
+		this.clearDependenciesAndBlocks();
+		this.addDependency(new RemoteToExternalDependency(this.request));
+
+		for (const [, value] of this.overrides) {
+			const block = new AsyncDependenciesBlock({});
+			const dep = new RemoteToExternalDependency(value);
+			block.addDependency(dep);
+			this.addBlock(block);
+		}
+
+		callback();
+	}
+
+	/**
+	 * @param {Chunk} chunk the chunk which condition should be checked
+	 * @param {Compilation} compilation the compilation
+	 * @returns {boolean} true, if the chunk is ok for the module
+	 */
+	chunkCondition(chunk, { chunkGraph }) {
+		return chunkGraph.getNumberOfEntryModules(chunk) > 0;
+	}
+
+	size(type) {
+		return 42;
+	}
+
+	/**
+	 * @returns {Set<string>} types availiable (do not mutate)
+	 */
+	getSourceTypes() {
+		return TYPES;
+	}
+
+	/**
+	 * @returns {string | null} absolute path which should be used for condition matching (usually the resource path)
+	 */
+	nameForCondition() {
+		return this.request;
+	}
+
+	/**
+	 * @param {CodeGenerationContext} context context for code generation
+	 * @returns {CodeGenerationResult} result
+	 */
+	codeGeneration({ runtimeTemplate, moduleGraph, chunkGraph }) {
+		const runtimeRequirements = new Set([RuntimeGlobals.module]);
+		const externalDep = this.dependencies[0];
+		const externalModule = moduleGraph.getModule(externalDep);
+		const externalModuleId = chunkGraph.getModuleId(externalModule);
+		let i = 0;
+		const source = Template.asString([
+			`var external = __webpack_require__(${externalModuleId});`,
+			"var overrides = {};",
+			Template.asString(
+				this.overrides.map(([key, value]) => {
+					const block = this.blocks[i++];
+					const dep = block.dependencies[0];
+					const module = moduleGraph.getModule(dep);
+					return `overrides[${JSON.stringify(
+						key
+					)}] = ${runtimeTemplate.basicFunction(
+						"",
+						`return ${runtimeTemplate.blockPromise({
+							block,
+							message: "",
+							chunkGraph,
+							runtimeRequirements
+						})}.then(${runtimeTemplate.basicFunction(
+							"",
+							`return ${runtimeTemplate.returningFunction(
+								runtimeTemplate.moduleRaw({
+									module,
+									chunkGraph,
+									request: "",
+									runtimeRequirements
+								})
+							)}`
+						)})`
+					)}`;
+				})
+			),
+			"external.override(overrides);",
+			"module.exports = external;"
+		]);
+		const sources = new Map();
+		sources.set("javascript", new RawSource(source));
+		return { sources, runtimeRequirements };
+	}
+}
+
+module.exports = RemoteModule;

--- a/lib/container/RemoteOverrideModule.js
+++ b/lib/container/RemoteOverrideModule.js
@@ -122,36 +122,36 @@ class RemoteModule extends Module {
 			`var external = __webpack_require__(${JSON.stringify(
 				externalModuleId
 			)});`,
-			"var overrides = {};",
-			Template.asString(
-				this.overrides.map(([key, value]) => {
-					const block = this.blocks[i++];
-					const dep = block.dependencies[0];
-					const module = moduleGraph.getModule(dep);
-					return `overrides[${JSON.stringify(
-						key
-					)}] = ${runtimeTemplate.basicFunction(
-						"",
-						`return ${runtimeTemplate.blockPromise({
-							block,
-							message: "",
-							chunkGraph,
-							runtimeRequirements
-						})}.then(${runtimeTemplate.basicFunction(
+			"external.override(Object.assign({",
+			Template.indent(
+				this.overrides
+					.map(([key, value]) => {
+						const block = this.blocks[i++];
+						const dep = block.dependencies[0];
+						const module = moduleGraph.getModule(dep);
+						return `${JSON.stringify(key)}: ${runtimeTemplate.basicFunction(
 							"",
-							`return ${runtimeTemplate.returningFunction(
-								runtimeTemplate.moduleRaw({
-									module,
-									chunkGraph,
-									request: "",
-									runtimeRequirements
-								})
-							)}`
-						)})`
-					)}`;
-				})
+							`return ${runtimeTemplate.blockPromise({
+								block,
+								message: "",
+								chunkGraph,
+								runtimeRequirements
+							})}.then(${runtimeTemplate.basicFunction(
+								"",
+								`return ${runtimeTemplate.returningFunction(
+									runtimeTemplate.moduleRaw({
+										module,
+										chunkGraph,
+										request: "",
+										runtimeRequirements
+									})
+								)}`
+							)})`
+						)}`;
+					})
+					.join(",\n")
 			),
-			"external.override(overrides);",
+			`}, ${RuntimeGlobals.overrides}));`,
 			"module.exports = external;"
 		]);
 		const sources = new Map();

--- a/lib/container/RemoteOverrideModule.js
+++ b/lib/container/RemoteOverrideModule.js
@@ -119,7 +119,9 @@ class RemoteModule extends Module {
 		const externalModuleId = chunkGraph.getModuleId(externalModule);
 		let i = 0;
 		const source = Template.asString([
-			`var external = __webpack_require__(${externalModuleId});`,
+			`var external = __webpack_require__(${JSON.stringify(
+				externalModuleId
+			)});`,
 			"var overrides = {};",
 			Template.asString(
 				this.overrides.map(([key, value]) => {

--- a/lib/container/RemoteOverrideModule.js
+++ b/lib/container/RemoteOverrideModule.js
@@ -10,6 +10,7 @@ const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
 const Module = require("../Module");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
+const RemoteOverrideDependency = require("./RemoteOverrideDependency");
 const RemoteToExternalDependency = require("./RemoteToExternalDependency");
 
 /** @typedef {import("../../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
@@ -68,7 +69,7 @@ class RemoteModule extends Module {
 
 		for (const [, value] of this.overrides) {
 			const block = new AsyncDependenciesBlock({});
-			const dep = new RemoteToExternalDependency(value);
+			const dep = new RemoteOverrideDependency(value);
 			block.addDependency(dep);
 			this.addBlock(block);
 		}

--- a/lib/container/RemoteOverrideModule.js
+++ b/lib/container/RemoteOverrideModule.js
@@ -6,13 +6,14 @@
 "use strict";
 
 const { RawSource } = require("webpack-sources");
+const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
 const Module = require("../Module");
 const RuntimeGlobals = require("../RuntimeGlobals");
-const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
-const RemoteToExternalDependency = require("./RemoteToExternalDependency");
 const Template = require("../Template");
+const RemoteToExternalDependency = require("./RemoteToExternalDependency");
 
 /** @typedef {import("../../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
+/** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
 /** @typedef {import("../ChunkGroup")} ChunkGroup */
 /** @typedef {import("../Compilation")} Compilation */
@@ -84,6 +85,10 @@ class RemoteModule extends Module {
 		return chunkGraph.getNumberOfEntryModules(chunk) > 0;
 	}
 
+	/**
+	 * @param {string=} type the source type for which the size should be estimated
+	 * @returns {number} the estimated size of the module (must be non-zero)
+	 */
 	size(type) {
 		return 42;
 	}

--- a/lib/container/RemoteOverrideModule.js
+++ b/lib/container/RemoteOverrideModule.js
@@ -95,7 +95,7 @@ class RemoteModule extends Module {
 	}
 
 	/**
-	 * @returns {Set<string>} types availiable (do not mutate)
+	 * @returns {Set<string>} types available (do not mutate)
 	 */
 	getSourceTypes() {
 		return TYPES;

--- a/lib/container/RemoteOverrideModule.js
+++ b/lib/container/RemoteOverrideModule.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-const { RawSource } = require("webpack-sources");
+const { OriginalSource } = require("webpack-sources");
 const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
 const Module = require("../Module");
 const RuntimeGlobals = require("../RuntimeGlobals");
@@ -155,7 +155,10 @@ class RemoteModule extends Module {
 			"module.exports = external;"
 		]);
 		const sources = new Map();
-		sources.set("javascript", new RawSource(source));
+		sources.set(
+			"javascript",
+			new OriginalSource(source, `webpack/remote-overrides ${this.request}`)
+		);
 		return { sources, runtimeRequirements };
 	}
 }

--- a/lib/container/RemoteOverrideModuleFactory.js
+++ b/lib/container/RemoteOverrideModuleFactory.js
@@ -1,0 +1,30 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra and Zackary Jackson @ScriptedAlchemy
+*/
+
+"use strict";
+
+const ModuleFactory = require("../ModuleFactory");
+const RemoteOverrideModule = require("./RemoteOverrideModule");
+
+/** @typedef {import("../ModuleFactory").ModuleFactoryCreateData} ModuleFactoryCreateData */
+/** @typedef {import("../ModuleFactory").ModuleFactoryResult} ModuleFactoryResult */
+/** @typedef {import("./RemoteToOverrideDependency")} RemoteToOverrideDependency */
+
+class RemoteOverrideModuleFactory extends ModuleFactory {
+	/**
+	 * @param {ModuleFactoryCreateData} data data object
+	 * @param {function(Error=, ModuleFactoryResult=): void} callback callback
+	 * @returns {void}
+	 */
+	create(data, callback) {
+		const dep =
+			/** @type {RemoteToOverrideDependency} */ (data.dependencies[0]);
+		callback(null, {
+			module: new RemoteOverrideModule(dep.request, dep.overrides)
+		});
+	}
+}
+
+module.exports = RemoteOverrideModuleFactory;

--- a/lib/container/RemoteRuntimeModule.js
+++ b/lib/container/RemoteRuntimeModule.js
@@ -1,0 +1,83 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const RuntimeGlobals = require("../RuntimeGlobals");
+const RuntimeModule = require("../RuntimeModule");
+const Template = require("../Template");
+
+/** @typedef {import("./RemoteModule")} RemoteModule */
+
+class RemoteRuntimeModule extends RuntimeModule {
+	constructor() {
+		super("remotes loading");
+	}
+
+	/**
+	 * @returns {string} runtime code
+	 */
+	generate() {
+		const { runtimeTemplate, chunkGraph, moduleGraph } = this.compilation;
+		const chunkToRemotesMapping = {};
+		const idToExternalAndNameMapping = {};
+		for (const chunk of this.chunk.getAllAsyncChunks()) {
+			const modules = chunkGraph.getChunkModulesIterableBySourceType(
+				chunk,
+				"remote"
+			);
+			if (!modules) continue;
+			const remotes = (chunkToRemotesMapping[chunk.id] = []);
+			for (const m of modules) {
+				const module = /** @type {RemoteModule} */ (m);
+				const name = module.internalRequest;
+				const id = chunkGraph.getModuleId(module);
+				const externalModule = moduleGraph.getModule(module.dependencies[0]);
+				const externalModuleId = chunkGraph.getModuleId(externalModule);
+				remotes.push(id);
+				idToExternalAndNameMapping[id] = [externalModuleId, name];
+			}
+		}
+		return Template.asString([
+			`var chunkMapping = ${JSON.stringify(
+				chunkToRemotesMapping,
+				null,
+				"\t"
+			)};`,
+			`var idToExternalAndNameMapping = ${JSON.stringify(
+				idToExternalAndNameMapping,
+				null,
+				"\t"
+			)};`,
+			`${
+				RuntimeGlobals.ensureChunkHandlers
+			}.remotes = ${runtimeTemplate.basicFunction("chunkId, promises", [
+				`if(${RuntimeGlobals.hasOwnProperty}(chunkMapping, chunkId)) {`,
+				Template.indent([
+					`chunkMapping[chunkId].forEach(${runtimeTemplate.basicFunction("id", [
+						"if(__webpack_modules__[id]) return;",
+						"var data = idToExternalAndNameMapping[id];",
+						"console.log(data);",
+						`promises.push(Promise.resolve(__webpack_require__(data[0]).get(data[1])).then(${runtimeTemplate.basicFunction(
+							"factory",
+							[
+								`__webpack_modules__[id] = ${runtimeTemplate.basicFunction(
+									"module",
+									[
+										"console.log(factory.toString());",
+										"module.exports = factory();"
+									]
+								)}`
+							]
+						)}))`
+					])});`
+				]),
+				"}"
+			])}`
+		]);
+	}
+}
+
+module.exports = RemoteRuntimeModule;

--- a/lib/container/RemoteRuntimeModule.js
+++ b/lib/container/RemoteRuntimeModule.js
@@ -59,16 +59,12 @@ class RemoteRuntimeModule extends RuntimeModule {
 					`chunkMapping[chunkId].forEach(${runtimeTemplate.basicFunction("id", [
 						"if(__webpack_modules__[id]) return;",
 						"var data = idToExternalAndNameMapping[id];",
-						"console.log(data);",
 						`promises.push(Promise.resolve(__webpack_require__(data[0]).get(data[1])).then(${runtimeTemplate.basicFunction(
 							"factory",
 							[
 								`__webpack_modules__[id] = ${runtimeTemplate.basicFunction(
 									"module",
-									[
-										"console.log(factory.toString());",
-										"module.exports = factory();"
-									]
+									["module.exports = factory();"]
 								)}`
 							]
 						)}))`

--- a/lib/container/RemoteToExternalDependency.js
+++ b/lib/container/RemoteToExternalDependency.js
@@ -1,0 +1,26 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const ModuleDependency = require("../dependencies/ModuleDependency");
+const makeSerializable = require("../util/makeSerializable");
+
+class RemoteToExternalDependency extends ModuleDependency {
+	constructor(request) {
+		super(request);
+	}
+
+	get type() {
+		return "remote to external";
+	}
+}
+
+makeSerializable(
+	RemoteToExternalDependency,
+	"webpack/lib/container/RemoteToExternalDependency"
+);
+
+module.exports = RemoteToExternalDependency;

--- a/lib/container/RemoteToOverrideDependency.js
+++ b/lib/container/RemoteToOverrideDependency.js
@@ -1,0 +1,37 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const ModuleDependency = require("../dependencies/ModuleDependency");
+const makeSerializable = require("../util/makeSerializable");
+
+class RemoteToOverrideDependency extends ModuleDependency {
+	constructor(request, overrides) {
+		super(request);
+		this.overrides = overrides;
+	}
+
+	get type() {
+		return "remote to override";
+	}
+
+	serialize(context) {
+		context.write(this.overrides);
+		super.serialize(context);
+	}
+
+	deserialize(context) {
+		this.overrides = context.read();
+		super.deserialize(context);
+	}
+}
+
+makeSerializable(
+	RemoteToOverrideDependency,
+	"webpack/lib/container/RemoteToOverrideDependency"
+);
+
+module.exports = RemoteToOverrideDependency;

--- a/lib/container/parseOptions.js
+++ b/lib/container/parseOptions.js
@@ -1,0 +1,31 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const parseOptions = (prefix, options, result) => {
+	if (Array.isArray(options)) {
+		for (const item of options) {
+			parseOptions(prefix, item, result);
+		}
+	} else if (typeof options === "string") {
+		result.push([prefix + options.replace(/^([^\w]+\/)+/, ""), options]);
+	} else if (options && typeof options === "object") {
+		for (const key of Object.keys(options)) {
+			const value = options[key];
+			if (typeof value === "string") {
+				result.push([prefix + key, value]);
+			} else {
+				parseOptions(prefix + key + "/", value, result);
+			}
+		}
+	}
+};
+
+module.exports = options => {
+	const result = [];
+	parseOptions("", options, result);
+	return result;
+};

--- a/lib/container/parseOptions.js
+++ b/lib/container/parseOptions.js
@@ -5,10 +5,10 @@
 
 "use strict";
 
-const parseOptions = (prefix, options, result) => {
+const parseOptionsInternal = (prefix, options, result) => {
 	if (Array.isArray(options)) {
 		for (const item of options) {
-			parseOptions(prefix, item, result);
+			parseOptionsInternal(prefix, item, result);
 		}
 	} else if (typeof options === "string") {
 		result.push([prefix + options.replace(/^([^\w]+\/)+/, ""), options]);
@@ -18,14 +18,20 @@ const parseOptions = (prefix, options, result) => {
 			if (typeof value === "string") {
 				result.push([prefix + key, value]);
 			} else {
-				parseOptions(prefix + key + "/", value, result);
+				parseOptionsInternal(prefix + key + "/", value, result);
 			}
 		}
 	}
 };
 
-module.exports = options => {
+/**
+ * @param {TODO} options options passed by the user
+ * @returns {[string, string][]} parsed options
+ */
+const parseOptions = options => {
 	const result = [];
-	parseOptions("", options, result);
+	parseOptionsInternal("", options, result);
 	return result;
 };
+
+module.exports = parseOptions;

--- a/lib/util/internalSerializables.js
+++ b/lib/util/internalSerializables.js
@@ -25,6 +25,8 @@ module.exports = {
 		require("../container/OverridableModule"),
 	"container/OverridableOriginalDependency": () =>
 		require("../container/OverridableOriginalDependency"),
+	"container/RemoteOverrideDependency": () =>
+		require("../container/RemoteOverrideDependency"),
 	"container/RemoteToExternalDependency": () =>
 		require("../container/RemoteToExternalDependency"),
 	"container/RemoteToOverrideDependency": () =>

--- a/lib/util/internalSerializables.js
+++ b/lib/util/internalSerializables.js
@@ -21,6 +21,8 @@ module.exports = {
 		require("../container/OverridableModule"),
 	"container/OverridableOriginalDependency": () =>
 		require("../container/OverridableOriginalDependency"),
+	"container/RemoteToExternalDependency": () =>
+		require("../container/RemoteToExternalDependency"),
 	"dependencies/AMDDefineDependency": () =>
 		require("../dependencies/AMDDefineDependency"),
 	"dependencies/AMDRequireArrayDependency": () =>

--- a/lib/util/internalSerializables.js
+++ b/lib/util/internalSerializables.js
@@ -17,6 +17,10 @@ module.exports = {
 	"cache/PackFileCacheStrategy": () =>
 		require("../cache/PackFileCacheStrategy"),
 	"cache/ResolverCachePlugin": () => require("../cache/ResolverCachePlugin"),
+	"container/OverridableModule": () =>
+		require("../container/OverridableModule"),
+	"container/OverridableOriginalDependency": () =>
+		require("../container/OverridableOriginalDependency"),
 	"dependencies/AMDDefineDependency": () =>
 		require("../dependencies/AMDDefineDependency"),
 	"dependencies/AMDRequireArrayDependency": () =>

--- a/lib/util/internalSerializables.js
+++ b/lib/util/internalSerializables.js
@@ -17,6 +17,10 @@ module.exports = {
 	"cache/PackFileCacheStrategy": () =>
 		require("../cache/PackFileCacheStrategy"),
 	"cache/ResolverCachePlugin": () => require("../cache/ResolverCachePlugin"),
+	"container/ContainerEntryDependency": () =>
+		require("../container/ContainerEntryDependency"),
+	"container/ContainerExposedDependency": () =>
+		require("../container/ContainerExposedDependency"),
 	"container/OverridableModule": () =>
 		require("../container/OverridableModule"),
 	"container/OverridableOriginalDependency": () =>

--- a/lib/util/internalSerializables.js
+++ b/lib/util/internalSerializables.js
@@ -23,6 +23,8 @@ module.exports = {
 		require("../container/OverridableOriginalDependency"),
 	"container/RemoteToExternalDependency": () =>
 		require("../container/RemoteToExternalDependency"),
+	"container/RemoteToOverrideDependency": () =>
+		require("../container/RemoteToOverrideDependency"),
 	"dependencies/AMDDefineDependency": () =>
 		require("../dependencies/AMDDefineDependency"),
 	"dependencies/AMDRequireArrayDependency": () =>

--- a/schemas/plugins/ContainerPlugin.json
+++ b/schemas/plugins/ContainerPlugin.json
@@ -1,0 +1,42 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "exposes": {
+      "description": "A map of modules you wish to expose",
+      "type": ["object", "array"]
+    },
+    "filename": {
+      "description": "The filename for this container relative path inside the `output.path` directory.",
+      "type": "string",
+      "absolutePath": false
+    },
+    "libraryTarget": {
+      "description": "Type of library",
+      "type": "string",
+      "enum": [
+        "var",
+        "this",
+        "window",
+        "self",
+        "global",
+        "commonjs",
+        "commonjs2",
+        "amd",
+        "amd-require",
+        "umd",
+        "umd2",
+        "system"
+      ]
+    },
+    "name": {
+      "description": "The name for this container",
+      "type": "string"
+    },
+    "overridables": {
+      "description": "An object for requests to override from host to this container",
+      "type": "object"
+    }
+  },
+  "required": ["name"]
+}

--- a/schemas/plugins/ContainerPlugin.json
+++ b/schemas/plugins/ContainerPlugin.json
@@ -1,10 +1,10 @@
 {
   "definitions": {
     "ArrayOfStringValues": {
-      "description": "Array of strings",
+      "description": "Array of strings.",
       "type": "array",
       "items": {
-        "description": "A non-empty string",
+        "description": "A non-empty string.",
         "type": "string",
         "minLength": 1
       }
@@ -27,71 +27,87 @@
       "additionalProperties": false,
       "properties": {
         "amd": {
-          "description": "Set comment for `amd` section in UMD",
+          "description": "Set comment for `amd` section in UMD.",
           "type": "string"
         },
         "commonjs": {
-          "description": "Set comment for `commonjs` (exports) section in UMD",
+          "description": "Set comment for `commonjs` (exports) section in UMD.",
           "type": "string"
         },
         "commonjs2": {
-          "description": "Set comment for `commonjs2` (module.exports) section in UMD",
+          "description": "Set comment for `commonjs2` (module.exports) section in UMD.",
           "type": "string"
         },
         "root": {
-          "description": "Set comment for `root` (global variable) section in UMD",
+          "description": "Set comment for `root` (global variable) section in UMD.",
           "type": "string"
         }
       }
     },
     "LibraryCustomUmdObject": {
-      "description": "Description object for all UMD variants of the library name",
+      "description": "Description object for all UMD variants of the library name.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "amd": {
-          "description": "Name of the exposed AMD library in the UMD",
-          "type": "string"
+          "description": "Name of the exposed AMD library in the UMD.",
+          "type": "string",
+          "minLength": 1
         },
         "commonjs": {
-          "description": "Name of the exposed commonjs export in the UMD",
-          "type": "string"
+          "description": "Name of the exposed commonjs export in the UMD.",
+          "type": "string",
+          "minLength": 1
         },
         "root": {
-          "description": "Name of the property exposed globally by a UMD library",
+          "description": "Name of the property exposed globally by a UMD library.",
           "anyOf": [
             {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             {
-              "$ref": "#/definitions/ArrayOfStringValues"
+              "type": "array",
+              "items": {
+                "description": "Part of the name of the property exposed globally by a UMD library.",
+                "type": "string",
+                "minLength": 1
+              }
             }
           ]
         }
       }
     },
     "LibraryExport": {
-      "description": "Specify which export should be exposed as library",
+      "description": "Specify which export should be exposed as library.",
       "anyOf": [
         {
-          "type": "string"
-        },
-        {
-          "$ref": "#/definitions/ArrayOfStringValues"
-        }
-      ]
-    },
-    "LibraryName": {
-      "description": "The name of the library (some types allow unnamed libraries too)",
-      "anyOf": [
-        {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         {
           "type": "array",
           "items": {
-            "description": "A part of the library name",
-            "type": "string"
+            "description": "Part of the export that should be exposed as library.",
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      ]
+    },
+    "LibraryName": {
+      "description": "The name of the library (some types allow unnamed libraries too).",
+      "anyOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "items": {
+            "description": "A part of the library name.",
+            "type": "string",
+            "minLength": 1
           }
         },
         {
@@ -100,7 +116,7 @@
       ]
     },
     "LibraryOptions": {
-      "description": "Options for library",
+      "description": "Options for library.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -123,7 +139,7 @@
       "required": ["type"]
     },
     "LibraryType": {
-      "description": "Type of library",
+      "description": "Type of library.",
       "enum": [
         "var",
         "module",
@@ -153,7 +169,7 @@
   "additionalProperties": false,
   "properties": {
     "exposes": {
-      "description": "A map of modules you wish to expose",
+      "description": "A map of modules you wish to expose.",
       "type": ["object", "array"]
     },
     "filename": {
@@ -165,11 +181,11 @@
       "$ref": "#/definitions/LibraryOptions"
     },
     "name": {
-      "description": "The name for this container",
+      "description": "The name for this container.",
       "type": "string"
     },
     "overridables": {
-      "description": "An object for requests to override from host to this container",
+      "description": "An object for requests to override from host to this container.",
       "type": ["object", "array"]
     }
   },

--- a/schemas/plugins/ContainerPlugin.json
+++ b/schemas/plugins/ContainerPlugin.json
@@ -1,4 +1,154 @@
 {
+  "definitions": {
+    "ArrayOfStringValues": {
+      "description": "Array of strings",
+      "type": "array",
+      "items": {
+        "description": "A non-empty string",
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "AuxiliaryComment": {
+      "description": "Add a comment in the UMD wrapper.",
+      "anyOf": [
+        {
+          "description": "Append the same comment above each import style.",
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/LibraryCustomUmdCommentObject"
+        }
+      ]
+    },
+    "LibraryCustomUmdCommentObject": {
+      "description": "Set explicit comments for `commonjs`, `commonjs2`, `amd`, and `root`.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "amd": {
+          "description": "Set comment for `amd` section in UMD",
+          "type": "string"
+        },
+        "commonjs": {
+          "description": "Set comment for `commonjs` (exports) section in UMD",
+          "type": "string"
+        },
+        "commonjs2": {
+          "description": "Set comment for `commonjs2` (module.exports) section in UMD",
+          "type": "string"
+        },
+        "root": {
+          "description": "Set comment for `root` (global variable) section in UMD",
+          "type": "string"
+        }
+      }
+    },
+    "LibraryCustomUmdObject": {
+      "description": "Description object for all UMD variants of the library name",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "amd": {
+          "description": "Name of the exposed AMD library in the UMD",
+          "type": "string"
+        },
+        "commonjs": {
+          "description": "Name of the exposed commonjs export in the UMD",
+          "type": "string"
+        },
+        "root": {
+          "description": "Name of the property exposed globally by a UMD library",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ArrayOfStringValues"
+            }
+          ]
+        }
+      }
+    },
+    "LibraryExport": {
+      "description": "Specify which export should be exposed as library",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/ArrayOfStringValues"
+        }
+      ]
+    },
+    "LibraryName": {
+      "description": "The name of the library (some types allow unnamed libraries too)",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "description": "A part of the library name",
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/LibraryCustomUmdObject"
+        }
+      ]
+    },
+    "LibraryOptions": {
+      "description": "Options for library",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auxiliaryComment": {
+          "$ref": "#/definitions/AuxiliaryComment"
+        },
+        "export": {
+          "$ref": "#/definitions/LibraryExport"
+        },
+        "name": {
+          "$ref": "#/definitions/LibraryName"
+        },
+        "type": {
+          "$ref": "#/definitions/LibraryType"
+        },
+        "umdNamedDefine": {
+          "$ref": "#/definitions/UmdNamedDefine"
+        }
+      },
+      "required": ["type"]
+    },
+    "LibraryType": {
+      "description": "Type of library",
+      "enum": [
+        "var",
+        "module",
+        "assign",
+        "this",
+        "window",
+        "self",
+        "global",
+        "commonjs",
+        "commonjs2",
+        "commonjs-module",
+        "amd",
+        "amd-require",
+        "umd",
+        "umd2",
+        "jsonp",
+        "system"
+      ]
+    },
+    "UmdNamedDefine": {
+      "description": "If `output.libraryTarget` is set to umd and `output.library` is set, setting this to true will name the AMD module.",
+      "type": "boolean"
+    }
+  },
+  "title": "ContainerPluginOptions",
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -11,23 +161,8 @@
       "type": "string",
       "absolutePath": false
     },
-    "libraryTarget": {
-      "description": "Type of library",
-      "type": "string",
-      "enum": [
-        "var",
-        "this",
-        "window",
-        "self",
-        "global",
-        "commonjs",
-        "commonjs2",
-        "amd",
-        "amd-require",
-        "umd",
-        "umd2",
-        "system"
-      ]
+    "library": {
+      "$ref": "#/definitions/LibraryOptions"
     },
     "name": {
       "description": "The name for this container",
@@ -35,7 +170,7 @@
     },
     "overridables": {
       "description": "An object for requests to override from host to this container",
-      "type": "object"
+      "type": ["object", "array"]
     }
   },
   "required": ["name"]

--- a/schemas/plugins/ContainerReferencePlugin.json
+++ b/schemas/plugins/ContainerReferencePlugin.json
@@ -1,0 +1,45 @@
+{
+  "title": "ContainerReferencePlugin",
+  "oneOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "remoteType": {
+          "description": "The libraryTarget of a remote build",
+          "type": "string",
+          "minLength": 1
+        },
+        "remotes": {
+          "description": "A list of remote scopes or namespaces that reference federated Webpack instances",
+          "anyOf": [
+            {
+              "description": "List of provided remote scopes",
+              "type": "array"
+            },
+            {
+              "description": "A object of key value pairs for remote scopes",
+              "type": "object",
+              "additionalProperties": true
+            }
+          ]
+        },
+        "overrides": {
+          "description": "A list of requests that should be overridable by the host container",
+          "anyOf": [
+            {
+              "description": "List of provided remote scopes",
+              "type": "array",
+              "minLength": 1
+            },
+            {
+              "description": "A object of key value pairs for remote scopes",
+              "type": "object",
+              "additionalProperties": true
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/schemas/plugins/ContainerReferencePlugin.json
+++ b/schemas/plugins/ContainerReferencePlugin.json
@@ -5,6 +5,21 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "overrides": {
+          "description": "A list of requests that should be overridable by the host container",
+          "anyOf": [
+            {
+              "description": "List of provided remote scopes",
+              "type": "array",
+              "minLength": 1
+            },
+            {
+              "description": "A object of key value pairs for remote scopes",
+              "type": "object",
+              "additionalProperties": true
+            }
+          ]
+        },
         "remoteType": {
           "description": "The libraryTarget of a remote build",
           "type": "string",
@@ -16,21 +31,6 @@
             {
               "description": "List of provided remote scopes",
               "type": "array"
-            },
-            {
-              "description": "A object of key value pairs for remote scopes",
-              "type": "object",
-              "additionalProperties": true
-            }
-          ]
-        },
-        "overrides": {
-          "description": "A list of requests that should be overridable by the host container",
-          "anyOf": [
-            {
-              "description": "List of provided remote scopes",
-              "type": "array",
-              "minLength": 1
             },
             {
               "description": "A object of key value pairs for remote scopes",

--- a/schemas/plugins/ContainerReferencePlugin.json
+++ b/schemas/plugins/ContainerReferencePlugin.json
@@ -6,34 +6,34 @@
       "additionalProperties": false,
       "properties": {
         "overrides": {
-          "description": "A list of requests that should be overridable by the host container",
+          "description": "A list of requests that should be overridable by the host container.",
           "anyOf": [
             {
-              "description": "List of provided remote scopes",
+              "description": "List of provided remote scopes.",
               "type": "array",
               "minLength": 1
             },
             {
-              "description": "A object of key value pairs for remote scopes",
+              "description": "A object of key value pairs for remote scopes.",
               "type": "object",
               "additionalProperties": true
             }
           ]
         },
         "remoteType": {
-          "description": "The libraryTarget of a remote build",
+          "description": "The libraryTarget of a remote build.",
           "type": "string",
           "minLength": 1
         },
         "remotes": {
-          "description": "A list of remote scopes or namespaces that reference federated Webpack instances",
+          "description": "A list of remote scopes or namespaces that reference federated Webpack instances.",
           "anyOf": [
             {
-              "description": "List of provided remote scopes",
+              "description": "List of provided remote scopes.",
               "type": "array"
             },
             {
-              "description": "A object of key value pairs for remote scopes",
+              "description": "A object of key value pairs for remote scopes.",
               "type": "object",
               "additionalProperties": true
             }

--- a/test/configCases/container/0-container-full/App.js
+++ b/test/configCases/container/0-container-full/App.js
@@ -1,0 +1,6 @@
+import React from "react";
+import ComponentA from "containerA/ComponentA";
+
+export default () => {
+	return `App rendered with [${React()}] and [${ComponentA()}]`;
+};

--- a/test/configCases/container/0-container-full/ComponentA.js
+++ b/test/configCases/container/0-container-full/ComponentA.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default () => {
+	return `ComponentA rendered with [${React()}]`;
+};

--- a/test/configCases/container/0-container-full/index.js
+++ b/test/configCases/container/0-container-full/index.js
@@ -1,0 +1,15 @@
+it("should load the component from container", () => {
+	return import("./App").then(({ default: App }) => {
+		const rendered = App();
+		expect(rendered).toBe(
+			"App rendered with [This is react 0.1.2] and [ComponentA rendered with [This is react 0.1.2]]"
+		);
+		return import("./upgrade-react").then(({ default: upgrade }) => {
+			upgrade();
+			const rendered = App();
+			expect(rendered).toBe(
+				"App rendered with [This is react 1.2.3] and [ComponentA rendered with [This is react 1.2.3]]"
+			);
+		});
+	});
+});

--- a/test/configCases/container/0-container-full/node_modules/react.js
+++ b/test/configCases/container/0-container-full/node_modules/react.js
@@ -1,0 +1,3 @@
+let version = "0.1.2";
+export default () => `This is react ${version}`;
+export function setVersion(v) { version = v; }

--- a/test/configCases/container/0-container-full/upgrade-react.js
+++ b/test/configCases/container/0-container-full/upgrade-react.js
@@ -1,0 +1,5 @@
+import { setVersion } from "react";
+
+export default function upgrade() {
+	setVersion("1.2.3");
+}

--- a/test/configCases/container/0-container-full/webpack.config.js
+++ b/test/configCases/container/0-container-full/webpack.config.js
@@ -1,0 +1,18 @@
+const ModuleFederationPlugin = require("../../../../lib/container/ModuleFederationPlugin");
+
+module.exports = {
+	plugins: [
+		new ModuleFederationPlugin({
+			name: "container",
+			library: { type: "commonjs-module" },
+			filename: "container.js",
+			exposes: {
+				ComponentA: "./ComponentA"
+			},
+			remotes: {
+				containerA: "./container.js"
+			},
+			shared: ["react"]
+		})
+	]
+};

--- a/test/configCases/container/1-container-full/App.js
+++ b/test/configCases/container/1-container-full/App.js
@@ -1,0 +1,7 @@
+import React from "react";
+import ComponentA from "containerA/ComponentA";
+import ComponentB from "containerB/ComponentB";
+
+export default () => {
+	return `App rendered with [${React()}] and [${ComponentA()}] and [${ComponentB()}]`;
+};

--- a/test/configCases/container/1-container-full/ComponentB.js
+++ b/test/configCases/container/1-container-full/ComponentB.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default () => {
+	return `ComponentB rendered with [${React()}]`;
+};

--- a/test/configCases/container/1-container-full/ComponentC.js
+++ b/test/configCases/container/1-container-full/ComponentC.js
@@ -1,0 +1,7 @@
+import React from "react";
+import ComponentA from "containerA/ComponentA";
+import ComponentB from "containerB/ComponentB";
+
+export default () => {
+	return `ComponentC rendered with [${React()}] and [${ComponentA()}] and [${ComponentB()}]`;
+};

--- a/test/configCases/container/1-container-full/index.js
+++ b/test/configCases/container/1-container-full/index.js
@@ -1,0 +1,15 @@
+it("should load the component from container", () => {
+	return import("./App").then(({ default: App }) => {
+		const rendered = App();
+		expect(rendered).toBe(
+			"App rendered with [This is react 2.1.0] and [ComponentA rendered with [This is react 2.1.0]] and [ComponentB rendered with [This is react 2.1.0]]"
+		);
+		return import("./upgrade-react").then(({ default: upgrade }) => {
+			upgrade();
+			const rendered = App();
+			expect(rendered).toBe(
+				"App rendered with [This is react 3.2.1] and [ComponentA rendered with [This is react 3.2.1]] and [ComponentB rendered with [This is react 3.2.1]]"
+			);
+		});
+	});
+});

--- a/test/configCases/container/1-container-full/node_modules/react.js
+++ b/test/configCases/container/1-container-full/node_modules/react.js
@@ -1,0 +1,3 @@
+let version = "2.1.0";
+export default () => `This is react ${version}`;
+export function setVersion(v) { version = v; }

--- a/test/configCases/container/1-container-full/upgrade-react.js
+++ b/test/configCases/container/1-container-full/upgrade-react.js
@@ -1,0 +1,5 @@
+import { setVersion } from "react";
+
+export default function upgrade() {
+	setVersion("3.2.1");
+}

--- a/test/configCases/container/1-container-full/webpack.config.js
+++ b/test/configCases/container/1-container-full/webpack.config.js
@@ -1,0 +1,19 @@
+const ModuleFederationPlugin = require("../../../../lib/container/ModuleFederationPlugin");
+
+module.exports = {
+	plugins: [
+		new ModuleFederationPlugin({
+			name: "container",
+			library: { type: "commonjs-module" },
+			filename: "container.js",
+			exposes: {
+				ComponentB: "./ComponentB"
+			},
+			remotes: {
+				containerA: "../0-container-full/container.js",
+				containerB: "./container.js"
+			},
+			shared: ["react"]
+		})
+	]
+};

--- a/test/configCases/container/2-container-full/App.js
+++ b/test/configCases/container/2-container-full/App.js
@@ -1,0 +1,6 @@
+import React from "react";
+import ComponentC from "containerB/ComponentC";
+
+export default () => {
+	return `App rendered with [${React()}] and [${ComponentC()}]`;
+};

--- a/test/configCases/container/2-container-full/ComponentB.js
+++ b/test/configCases/container/2-container-full/ComponentB.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default () => {
+	return `ComponentB rendered with [${React()}]`;
+};

--- a/test/configCases/container/2-container-full/index.js
+++ b/test/configCases/container/2-container-full/index.js
@@ -1,0 +1,15 @@
+it("should load the component from container", () => {
+	return import("./App").then(({ default: App }) => {
+		const rendered = App();
+		expect(rendered).toBe(
+			"App rendered with [This is react 8] and [ComponentC rendered with [This is react 8] and [ComponentA rendered with [This is react 8]] and [ComponentB rendered with [This is react 8]]]"
+		);
+		return import("./upgrade-react").then(({ default: upgrade }) => {
+			upgrade();
+			const rendered = App();
+			expect(rendered).toBe(
+				"App rendered with [This is react 9] and [ComponentC rendered with [This is react 9] and [ComponentA rendered with [This is react 9]] and [ComponentB rendered with [This is react 9]]]"
+			);
+		});
+	});
+});

--- a/test/configCases/container/2-container-full/node_modules/react.js
+++ b/test/configCases/container/2-container-full/node_modules/react.js
@@ -1,0 +1,3 @@
+let version = "8";
+export default () => `This is react ${version}`;
+export function setVersion(v) { version = v; }

--- a/test/configCases/container/2-container-full/upgrade-react.js
+++ b/test/configCases/container/2-container-full/upgrade-react.js
@@ -1,0 +1,5 @@
+import { setVersion } from "react";
+
+export default function upgrade() {
+	setVersion("9");
+}

--- a/test/configCases/container/2-container-full/webpack.config.js
+++ b/test/configCases/container/2-container-full/webpack.config.js
@@ -6,13 +6,8 @@ module.exports = {
 			name: "container",
 			library: { type: "commonjs-module" },
 			filename: "container.js",
-			exposes: {
-				ComponentB: "./ComponentB",
-				ComponentC: "./ComponentC"
-			},
 			remotes: {
-				containerA: "../0-container-full/container.js",
-				containerB: "./container.js"
+				containerB: "../1-container-full/container.js"
 			},
 			shared: ["react"]
 		})

--- a/test/configCases/container/container-entry-overridables/index.js
+++ b/test/configCases/container/container-entry-overridables/index.js
@@ -1,0 +1,23 @@
+it("should expose modules from the container", async () => {
+	const container = __non_webpack_require__("./container-file.js");
+	expect(container).toBeTypeOf("object");
+	expect(container.override).toBeTypeOf("function");
+	container.override({
+		value: () =>
+			new Promise(resolve => {
+				setTimeout(() => {
+					resolve(() => ({
+						__esModule: true,
+						default: "overriden-value"
+					}));
+				}, 100);
+			})
+	});
+	const testFactory = await container.get("test");
+	expect(testFactory).toBeTypeOf("function");
+	expect(testFactory()).toEqual(
+		nsObj({
+			default: "test overriden-value"
+		})
+	);
+});

--- a/test/configCases/container/container-entry-overridables/test.js
+++ b/test/configCases/container/container-entry-overridables/test.js
@@ -1,0 +1,3 @@
+import value from "./value";
+
+export default `test ${value}`;

--- a/test/configCases/container/container-entry-overridables/value.js
+++ b/test/configCases/container/container-entry-overridables/value.js
@@ -1,0 +1,1 @@
+export default "value";

--- a/test/configCases/container/container-entry-overridables/webpack.config.js
+++ b/test/configCases/container/container-entry-overridables/webpack.config.js
@@ -1,0 +1,19 @@
+const ContainerPlugin = require("../../../../lib/container/ContainerPlugin");
+
+module.exports = {
+	plugins: [
+		new ContainerPlugin({
+			name: "container",
+			filename: "container-file.js",
+			library: {
+				type: "commonjs-module"
+			},
+			exposes: {
+				test: "./test"
+			},
+			overridables: {
+				value: "./value"
+			}
+		})
+	]
+};

--- a/test/configCases/container/container-entry/index.js
+++ b/test/configCases/container/container-entry/index.js
@@ -1,12 +1,11 @@
 it("should expose modules from the container", async () => {
-	const file = __non_webpack_require__("./container-file.js");
-	expect(file).toBeTypeOf("object");
-	expect(file.container).toBeTypeOf("object");
-	expect(file.container.get).toBeTypeOf("function");
-	const testFactory = await file.container.get("test");
+	const container = __non_webpack_require__("./container-file.js");
+	expect(container).toBeTypeOf("object");
+	expect(container.get).toBeTypeOf("function");
+	const testFactory = await container.get("test");
 	expect(testFactory).toBeTypeOf("function");
 	expect(testFactory()).toBe("test");
-	const test2Factory = await file.container.get("test2");
+	const test2Factory = await container.get("test2");
 	expect(test2Factory).toBeTypeOf("function");
 	expect(test2Factory()).toEqual(
 		nsObj({

--- a/test/configCases/container/container-entry/index.js
+++ b/test/configCases/container/container-entry/index.js
@@ -1,0 +1,17 @@
+it("should expose modules from the container", async () => {
+	const file = __non_webpack_require__("./container-file.js");
+	expect(file).toBeTypeOf("object");
+	expect(file.container).toBeTypeOf("object");
+	expect(file.container.get).toBeTypeOf("function");
+	const testFactory = await file.container.get("test");
+	expect(testFactory).toBeTypeOf("function");
+	expect(testFactory()).toBe("test");
+	const test2Factory = await file.container.get("test2");
+	expect(test2Factory).toBeTypeOf("function");
+	expect(test2Factory()).toEqual(
+		nsObj({
+			default: "test2",
+			other: "other"
+		})
+	);
+});

--- a/test/configCases/container/container-entry/test.js
+++ b/test/configCases/container/container-entry/test.js
@@ -1,0 +1,1 @@
+module.exports = "test";

--- a/test/configCases/container/container-entry/test2.js
+++ b/test/configCases/container/container-entry/test2.js
@@ -1,0 +1,2 @@
+export default "test2";
+export const other = "other";

--- a/test/configCases/container/container-entry/webpack.config.js
+++ b/test/configCases/container/container-entry/webpack.config.js
@@ -1,0 +1,15 @@
+const ContainerPlugin = require("../../../../lib/container/ContainerPlugin");
+
+module.exports = {
+	plugins: [
+		new ContainerPlugin({
+			name: "container",
+			filename: "container-file.js",
+			libraryTarget: "commonjs",
+			exposes: {
+				test: "./test",
+				test2: "./test2"
+			}
+		})
+	]
+};

--- a/test/configCases/container/container-entry/webpack.config.js
+++ b/test/configCases/container/container-entry/webpack.config.js
@@ -5,7 +5,9 @@ module.exports = {
 		new ContainerPlugin({
 			name: "container",
 			filename: "container-file.js",
-			libraryTarget: "commonjs",
+			library: {
+				type: "commonjs-module"
+			},
 			exposes: {
 				test: "./test",
 				test2: "./test2"

--- a/test/configCases/container/container-reference-override/index.js
+++ b/test/configCases/container/container-reference-override/index.js
@@ -1,0 +1,3 @@
+it("should import the correct modules", () => {
+	return import("./module").then(({ test }) => test());
+});

--- a/test/configCases/container/container-reference-override/module.js
+++ b/test/configCases/container/container-reference-override/module.js
@@ -1,0 +1,7 @@
+import abc from "abc/hello-world";
+import other from "abc/other";
+
+export function test() {
+	expect(abc).toBe("ok hello-world");
+	expect(other).toBe("ok other");
+}

--- a/test/configCases/container/container-reference-override/new-test.js
+++ b/test/configCases/container/container-reference-override/new-test.js
@@ -1,0 +1,1 @@
+module.exports = x => `ok ${x}`;

--- a/test/configCases/container/container-reference-override/test.config.js
+++ b/test/configCases/container/container-reference-override/test.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+	moduleScope(scope) {
+		const o = {
+			test: () => () => x => `wrong ${x}`
+		};
+		scope.ABC = {
+			async get(module) {
+				const testFactory = await o["test"]();
+				const test = testFactory();
+				return () => {
+					return test(module);
+				};
+			},
+			override(overrides) {
+				Object.assign(o, overrides);
+			}
+		};
+	}
+};

--- a/test/configCases/container/container-reference-override/webpack.config.js
+++ b/test/configCases/container/container-reference-override/webpack.config.js
@@ -1,0 +1,15 @@
+const ContainerReferencePlugin = require("../../../../lib/container/ContainerReferencePlugin");
+
+module.exports = {
+	plugins: [
+		new ContainerReferencePlugin({
+			remoteType: "var",
+			remotes: {
+				abc: "ABC"
+			},
+			overrides: {
+				test: "./new-test"
+			}
+		})
+	]
+};

--- a/test/configCases/container/container-reference/index.js
+++ b/test/configCases/container/container-reference/index.js
@@ -1,0 +1,3 @@
+it("should import the correct modules", () => {
+	return import("./module").then(({ test }) => test());
+});

--- a/test/configCases/container/container-reference/module.js
+++ b/test/configCases/container/container-reference/module.js
@@ -1,0 +1,11 @@
+import abc from "abc/hello-world";
+import def, { module } from "def/hello-world";
+import def2, { module as module2 } from "def/hello/other/world";
+
+export function test() {
+	expect(abc).toBe("abc hello-world");
+	expect(def).toBe("def");
+	expect(def2).toBe("def");
+	expect(module).toBe("hello-world");
+	expect(module2).toBe("hello/other/world");
+}

--- a/test/configCases/container/container-reference/test.config.js
+++ b/test/configCases/container/container-reference/test.config.js
@@ -1,0 +1,26 @@
+module.exports = {
+	moduleScope(scope) {
+		scope.ABC = {
+			get(module) {
+				return new Promise(resolve => {
+					setTimeout(() => {
+						resolve(() => "abc " + module);
+					}, 100);
+				});
+			}
+		};
+		scope.DEF = {
+			get(module) {
+				return new Promise(resolve => {
+					setTimeout(() => {
+						resolve(() => ({
+							__esModule: true,
+							module,
+							default: "def"
+						}));
+					}, 100);
+				});
+			}
+		};
+	}
+};

--- a/test/configCases/container/container-reference/webpack.config.js
+++ b/test/configCases/container/container-reference/webpack.config.js
@@ -1,0 +1,13 @@
+const ContainerReferencePlugin = require("../../../../lib/container/ContainerReferencePlugin");
+
+module.exports = {
+	plugins: [
+		new ContainerReferencePlugin({
+			remoteType: "var",
+			remotes: {
+				abc: "ABC",
+				def: "DEF"
+			}
+		})
+	]
+};

--- a/test/configCases/container/overridables/cjs/test1.js
+++ b/test/configCases/container/overridables/cjs/test1.js
@@ -1,0 +1,1 @@
+module.exports = "original1-cjs";

--- a/test/configCases/container/overridables/cjs/test2.js
+++ b/test/configCases/container/overridables/cjs/test2.js
@@ -1,0 +1,1 @@
+module.exports = "original2-cjs";

--- a/test/configCases/container/overridables/index.js
+++ b/test/configCases/container/overridables/index.js
@@ -1,0 +1,76 @@
+__webpack_override__({
+	test1: () =>
+		new Promise(resolve => {
+			setTimeout(() => {
+				resolve(() => ({
+					__esModule: true,
+					default: "overriden1"
+				}));
+			}, 100);
+		}),
+	package: () =>
+		new Promise(resolve => {
+			setTimeout(() => {
+				resolve(() => "overriden-package");
+			}, 100);
+		}),
+	"options/test1": () => () => "1",
+	"nested1/options/test2": () => () => "2",
+	"nested2/deep/deep": () => () => "3"
+});
+
+it("should be able to override a esm overridable", () => {
+	return import("./modules/test1").then(m => {
+		expect(m.default).toBe("overriden1");
+	});
+});
+
+it("should be able to not override a esm overridable", () => {
+	return import("./modules/test2").then(m => {
+		expect(m.default).toBe("original2");
+	});
+});
+
+it("should be able to override a cjs overridable", () => {
+	return import("./cjs/test1").then(m => {
+		expect(m.default).toBe("overriden1");
+	});
+});
+
+it("should be able to not override a cjs overridable", () => {
+	return import("./cjs/test2").then(m => {
+		expect(m.default).toBe("original2-cjs");
+	});
+});
+
+it("should be able to override with a package name shortcut", () => {
+	return import("package").then(m => {
+		expect(m.default).toBe("overriden-package");
+	});
+});
+
+it("should be able to override a relative request via shortcut", () => {
+	return import("./options/test1").then(m => {
+		expect(m.default).toBe("1");
+	});
+});
+
+it("should be able to override a nested relative request via shortcut", () => {
+	return import("./options/test2").then(m => {
+		expect(m.default).toBe("2");
+	});
+});
+
+it("should be able to override a deep nested request", () => {
+	return import("./options/test3").then(m => {
+		expect(m.default).toBe("3");
+	});
+});
+
+it("should be able to override when fallback module has multiple chunks", () => {
+	return import("./splitChunks").then(m => {
+		expect(m.default).toBe(
+			"index+app+vendor+shared+shared-separate+shared+shared-separate"
+		);
+	});
+});

--- a/test/configCases/container/overridables/modules/test1.js
+++ b/test/configCases/container/overridables/modules/test1.js
@@ -1,0 +1,1 @@
+export default "original1";

--- a/test/configCases/container/overridables/modules/test2.js
+++ b/test/configCases/container/overridables/modules/test2.js
@@ -1,0 +1,1 @@
+export default "original2";

--- a/test/configCases/container/overridables/node_modules/package/index.js
+++ b/test/configCases/container/overridables/node_modules/package/index.js
@@ -1,0 +1,1 @@
+module.exports = "original-package";

--- a/test/configCases/container/overridables/options/test1.js
+++ b/test/configCases/container/overridables/options/test1.js
@@ -1,0 +1,1 @@
+module.exports = "test1";

--- a/test/configCases/container/overridables/options/test2.js
+++ b/test/configCases/container/overridables/options/test2.js
@@ -1,0 +1,1 @@
+module.exports = "test2";

--- a/test/configCases/container/overridables/options/test3.js
+++ b/test/configCases/container/overridables/options/test3.js
@@ -1,0 +1,1 @@
+module.exports = "test3";

--- a/test/configCases/container/overridables/splitChunks/app.js
+++ b/test/configCases/container/overridables/splitChunks/app.js
@@ -1,0 +1,4 @@
+import vendor from "./vendor";
+import shared from "./shared";
+import shared2 from "./shared-separate";
+export default "app+" + vendor + "+" + shared + "+" + shared2;

--- a/test/configCases/container/overridables/splitChunks/index.js
+++ b/test/configCases/container/overridables/splitChunks/index.js
@@ -1,0 +1,4 @@
+import app from "./app";
+import shared from "./shared";
+import shared2 from "./shared-separate";
+export default "index+" + app + "+" + shared + "+" + shared2;

--- a/test/configCases/container/overridables/splitChunks/shared-separate.js
+++ b/test/configCases/container/overridables/splitChunks/shared-separate.js
@@ -1,0 +1,1 @@
+export default "shared-separate";

--- a/test/configCases/container/overridables/splitChunks/shared.js
+++ b/test/configCases/container/overridables/splitChunks/shared.js
@@ -1,0 +1,1 @@
+export default "shared";

--- a/test/configCases/container/overridables/splitChunks/vendor.js
+++ b/test/configCases/container/overridables/splitChunks/vendor.js
@@ -1,0 +1,1 @@
+export default "vendor";

--- a/test/configCases/container/overridables/webpack.config.js
+++ b/test/configCases/container/overridables/webpack.config.js
@@ -1,0 +1,39 @@
+const OverridablesPlugin = require("../../../../lib/container/OverridablesPlugin");
+
+module.exports = {
+	plugins: [
+		new OverridablesPlugin([
+			{
+				test1: "./modules/test1.js",
+				test2: "./modules/test2"
+			},
+			{
+				test1: "./cjs/test1",
+				test2: "./cjs/test2.js",
+				nested1: ["./options/test2"],
+				nested2: {
+					deep: {
+						deep: "./options/test3"
+					}
+				}
+			},
+			"package",
+			"././options/test1",
+			"./splitChunks/app"
+		])
+	],
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				vendorTest: {
+					test: /splitChunks.vendor/,
+					enforce: true
+				},
+				sharedTest: {
+					test: /splitChunks.shared-separate/,
+					enforce: true
+				}
+			}
+		}
+	}
+};

--- a/tooling/format-schemas.js
+++ b/tooling/format-schemas.js
@@ -1,8 +1,10 @@
 const fs = require("fs");
 const path = require("path");
 const prettier = require("prettier");
+const baseSchema = require("../schemas/WebpackOptions.json");
 
 const schemasDir = path.resolve(__dirname, "../schemas");
+const baseDefs = new Map(Object.entries(baseSchema.definitions));
 
 // When --write is set, files will be written in place
 // Otherwise it only prints outdated files
@@ -75,6 +77,16 @@ const NESTED_ARRAY = ["oneOf", "anyOf", "allOf"];
 
 const processJson = json => {
 	json = sortObjectWithList(json, PROPERTIES);
+
+	if (json.definitions) {
+		json.definitions = { ...json.definitions };
+		for (const key of Object.keys(json.definitions)) {
+			const baseDef = baseDefs.get(key);
+			if (baseDef) {
+				json.definitions[key] = baseDef;
+			}
+		}
+	}
 
 	for (const name of NESTED_WITH_NAME) {
 		if (name in json && json[name] && typeof json[name] === "object") {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

This change exposes a way to set `publicPath` (see https://webpack.js.org/guides/public-path/#on-the-fly) on a remote so that the remote can still be deployed separately and hosted from `/`, but when it's hosted from say `app/${appName}` (with requests still being routed to the root of the remote host, i.e. `remoteHost/` - that's where all the assets live, like JS, CSS etc.), it could be configured to make asset requests to `/app/${appName}`.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Not yet, opening this draft PR to facilitate a discussion.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

How to make use of this feature, what it enables.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->


## Open Questions

### Where to invoke

Once this feature is exposed, what would be the best place to invoke this? In mine and @sebinsua's experiments, we're dynamically loading `remoteEntry.js` in the host app code so we have a way of knowing when it's loaded, and can then check `window[remoteIdentifier] !== undefined` and call ``window[remoteIdentifier].setPublicPath(`/app/${appName}`)``.

@ScriptedAlchemy has suggested this kind of config:

```js
remotes: {
  'some-app': {
    publicPath: '/app/some-app/'
  }
}
```

### CommonJS

How would this work in CommonJS environments, would we just ignore it (likely would)?